### PR TITLE
Turkish translation

### DIFF
--- a/src/translations/mp3diags_fr_FR.ts
+++ b/src/translations/mp3diags_fr_FR.ts
@@ -554,7 +554,7 @@ Erreur: %1</translation>
     <message>
         <location filename="../ApeStream.cpp" line="191"/>
         <source>Tag missing header or footer.</source>
-        <translation>Tag avec en-tête ou &apos;footer&apos;.</translation>
+        <translation>Tag avec en-tête ou &apos;footer&apos; manquant.</translation>
     </message>
 </context>
 <context>
@@ -2059,7 +2059,7 @@ Ceci est utile pour créer des fichiers M3U contenant des chemins relatifs.</tra
         <location filename="../ExportDlgImpl.cpp" line="325"/>
         <source>EWST</source>
         <comment>the letters are the initials of the 4 severity levels: Error, Warning, Support, Trace</comment>
-        <translatorcomment>ces lettres sont les initiales des 4 niveaux de garvité : Erreur, Avertissement, Support, Trace</translatorcomment>
+        <translatorcomment>ces lettres sont les initiales des 4 niveaux de gravité : Erreur, Avertissement, Support, Trace</translatorcomment>
         <translation>EAST</translation>
     </message>
     <message>
@@ -3682,7 +3682,7 @@ Arrêt...</translation>
     <message>
         <location filename="../main.cpp" line="425"/>
         <source>Folder &quot;%1&quot; doesn&apos;t exist. The program will exit ...</source>
-        <translation>Le fichier &quot;%1&quot; n&apos;existe pas. Le programme va s&apos;arrêter...</translation>
+        <translation>Le dossier &quot;%1&quot; n&apos;existe pas. Le programme va s&apos;arrêter...</translation>
     </message>
     <message>
         <location filename="../main.cpp" line="464"/>
@@ -4989,7 +4989,7 @@ Ceci est supposé être un fichier qui n&apos;existe pas encore. Vous n&apos;ave
     <message>
         <location filename="../SessionsDlgImpl.cpp" line="424"/>
         <source>Do you really want to erase the current session?</source>
-        <translation>Voulez-vous vraiemnt effacer la session courante ?</translation>
+        <translation>Voulez-vous vraiment effacer la session courante ?</translation>
     </message>
     <message>
         <location filename="../SessionsDlgImpl.cpp" line="424"/>
@@ -5489,7 +5489,7 @@ correspondante(s) de l&apos;onglet &quot;Autres&quot;</translation>
     <message>
         <location filename="../TagEditorDlgImpl.cpp" line="1776"/>
         <source>If your current folder fits one of these cases or you simply have consistently named files that you would prefer to use as a source of track info, you may want to take a look at the tag editor&apos;s patterns, at %1</source>
-        <translation>Si le dossier actuel est dans un tel cas ou si vous avez nommé de façon cohérente les fichiers pour les utiliser comme source d&apos;infos sur les pistes, les motifs de l&apos;éditeur de tags sur %1 peuvennt vous être utiles</translation>
+        <translation>Si le dossier actuel est dans un tel cas ou si vous avez nommé de façon cohérente les fichiers pour les utiliser comme source d&apos;infos sur les pistes, les motifs de l&apos;éditeur de tags sur %1 peuvent vous être utiles</translation>
     </message>
     <message>
         <location filename="../TagEditorDlgImpl.cpp" line="1776"/>

--- a/src/translations/mp3diags_tr_TR.ts
+++ b/src/translations/mp3diags_tr_TR.ts
@@ -1,0 +1,7021 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr_TR">
+<context>
+    <name>AboutDlg</name>
+    <message>
+        <location filename="../About.ui" line="14"/>
+        <source>About MP3 Diags</source>
+        <translation>MP3 Diags Hakkında</translation>
+    </message>
+    <message>
+        <location filename="../About.ui" line="58"/>
+        <source>MP3 Diags x.y.z</source>
+        <translation>MP3 Diags x.y.z</translation>
+    </message>
+    <message>
+        <location filename="../About.ui" line="75"/>
+        <source>About</source>
+        <translation>Hakkında</translation>
+    </message>
+    <message>
+        <location filename="../About.ui" line="110"/>
+        <source>System info</source>
+        <translation>Sistem bilgileri</translation>
+    </message>
+    <message>
+        <location filename="../About.ui" line="120"/>
+        <source>GPL V2 (for the program)</source>
+        <translation>GPL V2 (program için)</translation>
+    </message>
+    <message>
+        <location filename="../About.ui" line="130"/>
+        <source>LGPL V3 (for the icons)</source>
+        <translation>LGPL V3 (ikonlar için)</translation>
+    </message>
+    <message>
+        <location filename="../About.ui" line="140"/>
+        <source>GPL V3 (for the icons)</source>
+        <translation>GPL V3 (ikonlar için)</translation>
+    </message>
+    <message>
+        <location filename="../About.ui" line="150"/>
+        <source>LGPL V2.1 (for Qt)</source>
+        <translation>LGPL V2.1 (Qt için)</translation>
+    </message>
+    <message>
+        <location filename="../About.ui" line="160"/>
+        <source>Boost license</source>
+        <translation>Boost lisansı</translation>
+    </message>
+    <message>
+        <location filename="../About.ui" line="170"/>
+        <source>zlib license</source>
+        <translation>zlib lisansı</translation>
+    </message>
+    <message>
+        <location filename="../About.ui" line="180"/>
+        <source>Apache 2.0 (for OpenSSL)</source>
+        <translation>Apache 2.0 (OpenSSL için)</translation>
+    </message>
+    <message>
+        <location filename="../About.ui" line="190"/>
+        <source>OpenSSL 1</source>
+        <translation>OpenSSL 1</translation>
+    </message>
+    <message>
+        <location filename="../About.ui" line="222"/>
+        <source>OK</source>
+        <translation>Tamam</translation>
+    </message>
+</context>
+<context>
+    <name>AboutDlgImpl</name>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="64"/>
+        <source>Written by %1, %2</source>
+        <translation>%1, %2 tarafından yazılmıştır</translation>
+    </message>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="65"/>
+        <source>Command-line mode by %1, %2</source>
+        <translation>Komut satırı kipi %1, %2 tarafından</translation>
+    </message>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="66"/>
+        <location filename="../AboutDlgImpl.cpp" line="67"/>
+        <location filename="../AboutDlgImpl.cpp" line="68"/>
+        <source>%1 translation by %2, %3</source>
+        <translation>%1 tercüme %2, %3 tarafından</translation>
+    </message>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="66"/>
+        <source>Czech</source>
+        <translation>Çekçe</translation>
+    </message>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="67"/>
+        <source>German</source>
+        <translation>Almanca</translation>
+    </message>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="68"/>
+        <source>French</source>
+        <translation>Fransızca</translation>
+    </message>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="69"/>
+        <source>Distributed under %1</source>
+        <translation>%1 lisansı kapsamında yayınlanmıştır</translation>
+    </message>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="70"/>
+        <source>Using %1, released under %2</source>
+        <translation>Bu yazılım, %2 kapsamındaki %1 kullanır</translation>
+    </message>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="71"/>
+        <source>Using %1, released under the %2zlib License%3</source>
+        <translation>Bu yazılım, %2zlib lisansı%3 kapsamındaki %1 kullanır</translation>
+    </message>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="72"/>
+        <source>Using %1 and %2, distributed under the %3Boost Software License%4</source>
+        <translation>Bu yazılım, %3Boost yazılım lisansı%4 kapsamında yayınlanan %1 ve %2 kullanır</translation>
+    </message>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="75"/>
+        <source>Using %1 for secure internet connections, released under the OpenSSL License and the original SSLeay License, available %2here%3</source>
+        <translation>Güvenli İnternet bağlantıları için %1 kullanılmaktadır, OpenSSL lisansı kapsamında ve orijinal SSLeay lisansı kapsamında yayınlanmıştır ve %2burada%3 bulunabilir</translation>
+    </message>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="76"/>
+        <source>Using %1 for secure internet connections, released under the %2Apache License v2.0%3</source>
+        <translation>Güvenli İnternet bağlantıları için %1 kullanılmaktadır, %2Apache Lisansı v2.0%3 kapsamında yayınlanmıştır</translation>
+    </message>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="78"/>
+        <source>Using original and modified icons from the %1 for %2, distributed under %3LGPL V3%4</source>
+        <translation>Bu yazılım, %3LGPL V3%4 kapsamında yayınlanmış orijinal ve değiştirilmiş %2 için %1 ikonlarını kullanır</translation>
+    </message>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="80"/>
+        <source>Using web services provided by %1 to retrieve album data</source>
+        <translation>Bu yazılım, albüm verilerini almak için %1 tarafından sağlanan hizmetleri kullanır</translation>
+    </message>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="82"/>
+        <source>Built with %1 and using %2 libraries</source>
+        <translation>%1 ile derlenmiştir ve %2 kütüphanelerini kullanır</translation>
+    </message>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="84"/>
+        <source>Home page and documentation: %1</source>
+        <translation>İnternet sitesi ve belgelendirme: %1</translation>
+    </message>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="85"/>
+        <source>Feedback and support: %1 or %2 at SourceForge</source>
+        <translation>Geri bildirim ve destek: SourceForge üzerinde %1 veya %2</translation>
+    </message>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="86"/>
+        <source>Bug reports and feature requests: %1 at SourceForge</source>
+        <translation>Hata raporları ve yeni işlev talepleri: SourceForge üzerinde %1 konumunda</translation>
+    </message>
+    <message>
+        <location filename="../AboutDlgImpl.cpp" line="87"/>
+        <source>Change log for the latest version: %1</source>
+        <translation>Son sürüm için değişiklikler günlüğü: %1</translation>
+    </message>
+</context>
+<context>
+    <name>AlbumInfoDownloaderDlg</name>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="14"/>
+        <source>WWW</source>
+        <translation>WWW</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="23"/>
+        <location filename="../AlbumInfoDownloader.ui" line="79"/>
+        <source>Search</source>
+        <translation>Ara</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="32"/>
+        <location filename="../AlbumInfoDownloader.ui" line="104"/>
+        <source>Artist</source>
+        <translation>Sanatçı</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="52"/>
+        <location filename="../AlbumInfoDownloader.ui" line="124"/>
+        <source>Album</source>
+        <translation>Albüm</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="72"/>
+        <source>Match count</source>
+        <translation>Eşleşme sayısı</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="89"/>
+        <source>Results</source>
+        <translation>Neticeler</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="144"/>
+        <source>Released</source>
+        <translation>Yayın tarihi</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="173"/>
+        <source>Genre</source>
+        <translation>Tür</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="193"/>
+        <source>Use</source>
+        <translation>Kullan</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="203"/>
+        <source>Format</source>
+        <translation>Biçim</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="230"/>
+        <source>Amazon</source>
+        <translation>Amazon</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="291"/>
+        <location filename="../AlbumInfoDownloader.ui" line="486"/>
+        <source>Image</source>
+        <translation>Resim</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="325"/>
+        <source>Image size</source>
+        <translation>Resim boyutu</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="413"/>
+        <source>ResultNo</source>
+        <translation>Sonuç sayısı</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="420"/>
+        <source>Previous album</source>
+        <translation>Önceki albüm</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="423"/>
+        <location filename="../AlbumInfoDownloader.ui" line="465"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="434"/>
+        <source>Previous image or album</source>
+        <translation>Önceki resim veya albüm</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="437"/>
+        <source>p</source>
+        <translation>ö</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="448"/>
+        <source>Next image or album</source>
+        <translation>Sonraki resim veya albüm</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="451"/>
+        <source>n</source>
+        <translation>s</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="462"/>
+        <source>Next album</source>
+        <translation>Sonraki albüm</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="479"/>
+        <source>    Filter:</source>
+        <translation>    Filtre :</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="493"/>
+        <source>CD</source>
+        <translation>CD</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="500"/>
+        <source>Track count</source>
+        <translation>Parça sayısı</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="548"/>
+        <source>Volume</source>
+        <translation>Ses düzeyi</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="568"/>
+        <source>Save image</source>
+        <translation>Resmi kaydet</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="575"/>
+        <source>Save all</source>
+        <translation>Tümünü kaydet</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloader.ui" line="582"/>
+        <source>Cancel</source>
+        <translation>İptal et</translation>
+    </message>
+</context>
+<context>
+    <name>AlbumInfoDownloaderDlgImpl</name>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="195"/>
+        <source>not found at amazon.com</source>
+        <translation>amazon.com üzerinde bulunamadı</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="229"/>
+        <source>searching ...</source>
+        <translation>arama devam ediyor ...</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="218"/>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="285"/>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="291"/>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="340"/>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="346"/>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="715"/>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="721"/>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="797"/>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="810"/>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="825"/>
+        <source>Error</source>
+        <translation>Hata</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="218"/>
+        <source>You must specify at least an artist or an album</source>
+        <translation>En az bir sanatçı veya albüm belirtmeniz gerekmektedir</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="285"/>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="340"/>
+        <source>You cannot save the results now, because a request is still pending</source>
+        <translation>Sonuçları şimdi kaydedemezsiniz çünkü bir talep hâlâ beklemededir</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="291"/>
+        <source>You cannot save the results now, because no album is loaded</source>
+        <translation>Sonuçları şimdi kaydedemezsiniz çünkü hiçbir albüm yüklenmemiştir</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="317"/>
+        <source>You may want to use a different volume selection on this multi-volume release.
+
+</source>
+        <translation>Bu çok parçalı yayında başka bir parça seçimi kullanmak isteyebilirsiniz.
+
+</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="321"/>
+        <source>A number of %1 tracks were expected, but your selection contains %2. Additional tracks will be discarded.
+
+%3Save anyway?</source>
+        <translation>%1 parça bekleniyordu fakat seçiminiz %2 parça içermektedir. İlave parçalar görmezden gelinecektir.
+
+%3Yine de kaydedilsin mi?</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="325"/>
+        <source>A number of %1 tracks were expected, but your selection only contains %2. Remaining tracks will get null values.
+
+%3Save anyway?</source>
+        <translation>%1 parça bekleniyordu fakat seçiminiz sadece %2 parça içermektedir. Kalan parçaların değeri sıfır olabilir.
+
+%3Yine de kaydedilsin mi?</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="328"/>
+        <source>Count inconsistency</source>
+        <translation>Sayım tutarsızlığı</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="328"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Kaydet</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="328"/>
+        <source>Cancel</source>
+        <translation>İptal et</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="346"/>
+        <source>You cannot save any image now, because there is no image loaded</source>
+        <translation>Şu an hiçbir resim kaydedemezsiniz çünkü hiçbir resim yüklü değildir</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="550"/>
+        <source>request error</source>
+        <translation>talep hatası</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="574"/>
+        <source>received %1 bytes</source>
+        <translation>%1 bayt alındı</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="583"/>
+        <source>received very short response; aborting request ...</source>
+        <translation>çok kısa bir cevap alındı, talep iptal ediliyor...</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="598"/>
+        <source>Original: %1kB, %2x%3</source>
+        <translation>Orijinal: %1KB, %2x%3</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="611"/>
+        <source>
+Recompressed to: %1kB, %2x%3</source>
+        <translation>
+%1 KB olarak tekrar sıkıştırıldı, %2x%3</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="615"/>
+        <source>
+Not recompressed</source>
+        <translation>
+Tekrar sıkıştırılmadı</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="715"/>
+        <source>Failed to load the image</source>
+        <translation>Resmin yüklenmesi başarısız oldu</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="723"/>
+        <source>Error loading image
+</source>
+        <translation>Resmin yüklenmesi esnasında hata
+</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="797"/>
+        <source>Couldn&apos;t process the search result. (Usually this means that the server is busy, so trying later might work.)
+
+Error: %1</source>
+        <translation>Arama sonucu işlenemedi. (Genelde bu, sunucunun meşgul olduğu anlamına gelir, yani daha sonra denemek işe yarayabilir.)
+
+Hata: %1</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="825"/>
+        <source>Couldn&apos;t process the album information. (Usually this means that the server is busy, so trying later might work.)
+
+Error: %1</source>
+        <translation>Albüm bilgisi işlenemedi. (Genelde bu, sunucunun meşgul olduğu anlamına gelir, yani daha sonra denemek işe yarayabilir.)
+
+Hata: %1</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="642"/>
+        <source>init error</source>
+        <translation>başlatma hatası</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="661"/>
+        <source>unexpected result</source>
+        <translation>beklenmedik cevap</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="681"/>
+        <source>empty string received</source>
+        <translation>boş dize alındı</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="792"/>
+        <source>search results received</source>
+        <translation>sonuç alındı</translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t process the search result. (Usually this means that the server is busy, so trying later might work.)</source>
+        <translation type="vanished">Arama sonucu işlenemedi. (Bu, genelde sunucunun meşgul olduğu anlamına gelir yani daha sonra tekrar denemek işe yarayabilir.)</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="810"/>
+        <source>No results found</source>
+        <translation>Hiçbir sonuç bulunamadı</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="820"/>
+        <source>album info received</source>
+        <translation>albüm bilgisi alındı</translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t process the album information. (Usually this means that the server is busy, so trying later might work.)</source>
+        <translation type="vanished">Albüm bilgileri işlenemedi. (Bu, genelde sunucunun meşgul olduğu manasına gelir yani daha sonra tekrar denemek işe yarayabilir.)</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="843"/>
+        <source>image received</source>
+        <translation>resim alındı</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="925"/>
+        <source>&lt;All&gt;</source>
+        <translation>&lt;Tümü&gt;</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="930"/>
+        <source>Album %1/%2%3, image %4/%5</source>
+        <translation>Albüm %1/%2%3, resim %4/%5</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="940"/>
+        <source>No image
+</source>
+        <translation>Resim yok
+</translation>
+    </message>
+    <message>
+        <location filename="../DiscogsDownloader.cpp" line="747"/>
+        <location filename="../MusicBrainzDownloader.cpp" line="789"/>
+        <source>getting album info ...</source>
+        <translation>albüm bilgileri alınıyor ...</translation>
+    </message>
+    <message>
+        <location filename="../DiscogsDownloader.cpp" line="772"/>
+        <location filename="../MusicBrainzDownloader.cpp" line="823"/>
+        <source>getting image ...</source>
+        <translation>resim alınıyor ...</translation>
+    </message>
+</context>
+<context>
+    <name>ApeItem</name>
+    <message>
+        <location filename="../ApeStream.cpp" line="112"/>
+        <source>Ape stream whose items have unsupported flags.</source>
+        <translation>Unsurlarının desteklenmeyen bayrakları bulunan Ape akışı.</translation>
+    </message>
+    <message>
+        <location filename="../ApeStream.cpp" line="124"/>
+        <source>Ape Item seems too big. Although the size may be any 32-bit integer, 256 bytes should be enough in practice. If this message is determined to be mistaken, it will be removed in the future. Item key: %1; item size: %2</source>
+        <translation>Ape unsuru çok büyük gibi duruyor. Her ne kadar boyut herhangi bir 32 bit tamsayı olabilse de, pratikte 256 baytın kafi gelmesi beklenir. Şayet bu mesajın hatalı olduğu belirlenirse gelecekte kaldırılacaktır. Unsur anahtarı: %1 ; unsur boyutu: %2</translation>
+    </message>
+</context>
+<context>
+    <name>ApeStream</name>
+    <message>
+        <location filename="../ApeStream.cpp" line="191"/>
+        <source>Tag missing header or footer.</source>
+        <translation>Etikette başlık veya altbilgi eksik.</translation>
+    </message>
+</context>
+<context>
+    <name>CommonData</name>
+    <message>
+        <location filename="../CommonData.cpp" line="496"/>
+        <source>Info</source>
+        <translation>Bilgi</translation>
+    </message>
+    <message>
+        <location filename="../CommonData.cpp" line="496"/>
+        <source>The font changes will only be used after restarting the application.</source>
+        <translation>Yazı tipi değişiklikleri sadece uygulama yeniden başlatıldığında dikkate alınacaktır.</translation>
+    </message>
+    <message>
+        <location filename="../CommonData.cpp" line="727"/>
+        <source>Error</source>
+        <translation>Hata</translation>
+    </message>
+    <message>
+        <location filename="../CommonData.cpp" line="727"/>
+        <source>There was an error setting up the directories containing MP3 files. You will have to define them again.</source>
+        <translation>MP3 dosyalarını içeren dizinlerin yapılandırılması esnasında bir hata meydana geldi. Onları yeniden tanımlamanız gerekmektedir.</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigDlg</name>
+    <message>
+        <location filename="../Config.ui" line="20"/>
+        <source>Configuration</source>
+        <translation>Yapılandırma</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="39"/>
+        <source>Files</source>
+        <translation>Dosyalar</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="54"/>
+        <source>Simple view</source>
+        <translation>Sade görüntüleme</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="70"/>
+        <source>Full view</source>
+        <translation>Tam görüntüleme</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="108"/>
+        <source>Removable TextLabel</source>
+        <translation>Silinebilir TextLabel</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="122"/>
+        <source>Tab 1</source>
+        <translation>Sekme 1</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="143"/>
+        <source>Don&apos;t create backup for modified files</source>
+        <translation>Değiştirilmiş dosyalar için yedekleme oluşturma</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="155"/>
+        <source>Create backup for modified files in</source>
+        <translation>Değiştirilmiş dosyalar için şurada yedekleme oluştur</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="165"/>
+        <location filename="../Config.ui" line="362"/>
+        <location filename="../Config.ui" line="524"/>
+        <location filename="../Config.ui" line="695"/>
+        <location filename="../Config.ui" line="753"/>
+        <location filename="../Config.ui" line="801"/>
+        <location filename="../Config.ui" line="849"/>
+        <location filename="../Config.ui" line="957"/>
+        <location filename="../Config.ui" line="1051"/>
+        <location filename="../Config.ui" line="1145"/>
+        <location filename="../Config.ui" line="1239"/>
+        <source>...</source>
+        <translatorcomment>...</translatorcomment>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="177"/>
+        <source>Custom settings (go to full view to make changes)</source>
+        <translation>Kişiselleştirilmiş parametreler (değişiklik yapmak için tam görüntülemeye gidin)</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="198"/>
+        <source>Tab 2</source>
+        <translation>Sekme 2</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="217"/>
+        <source>Original file that would be changed</source>
+        <translation>Değiştirilecek orijinal dosya</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="229"/>
+        <location filename="../Config.ui" line="398"/>
+        <source>Don&apos;t touch</source>
+        <translation>Dokunma</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="236"/>
+        <location filename="../Config.ui" line="405"/>
+        <source>Erase</source>
+        <translation>Sil</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="243"/>
+        <location filename="../Config.ui" line="412"/>
+        <source>Move and change the name</source>
+        <translation>Taşı ve yeniden isimlendir</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="250"/>
+        <location filename="../Config.ui" line="419"/>
+        <source>Move but change the name only if a name collision would occur</source>
+        <translation>Taşı fakat ismi sadece bir isim çakışması olacaksa değiştir</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="257"/>
+        <location filename="../Config.ui" line="426"/>
+        <source>Change name</source>
+        <translation>Yeniden isimlendir</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="264"/>
+        <source>Move if the destination doesn&apos;t already exist; erase if it does</source>
+        <translation>Hedef zaten mevcut değilse taşı, mevcutsa sil</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="274"/>
+        <location filename="../Config.ui" line="436"/>
+        <location filename="../Config.ui" line="584"/>
+        <source>Name change params</source>
+        <translation>Yeniden isimlendirme parametreleri</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="283"/>
+        <location filename="../Config.ui" line="445"/>
+        <location filename="../Config.ui" line="593"/>
+        <source>Identifying label</source>
+        <translation>Tanımlayıcı etiket</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="298"/>
+        <location filename="../Config.ui" line="460"/>
+        <location filename="../Config.ui" line="608"/>
+        <source>Don&apos;t use an identifying label</source>
+        <translation>Tanımlayıcı etiket kullanma</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="305"/>
+        <location filename="../Config.ui" line="467"/>
+        <source>Use &quot;orig&quot; as an identifying label</source>
+        <translation>Tanımlayıcı etiket olarak &quot;orig&quot; kullan</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="315"/>
+        <location filename="../Config.ui" line="477"/>
+        <location filename="../Config.ui" line="625"/>
+        <source>Counter</source>
+        <translation>Sayaç</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="330"/>
+        <location filename="../Config.ui" line="492"/>
+        <location filename="../Config.ui" line="640"/>
+        <source>Always use a counter</source>
+        <translation>Daima bir sayaç kullan</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="337"/>
+        <location filename="../Config.ui" line="499"/>
+        <location filename="../Config.ui" line="647"/>
+        <source>Only use a counter when a name collision would occur</source>
+        <translation>Sayacı sadece bir isim çakışması olacaksa kullan</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="350"/>
+        <location filename="../Config.ui" line="512"/>
+        <location filename="../Config.ui" line="660"/>
+        <source>Destination</source>
+        <translation>Hedef</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="386"/>
+        <source>Original file that would not be changed</source>
+        <translation>Değiştirilmeyecek orijinal dosya</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="548"/>
+        <source>Changed file</source>
+        <translation>Değiştirilmiş dosya</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="560"/>
+        <location filename="../Config.ui" line="778"/>
+        <location filename="../Config.ui" line="826"/>
+        <source>Don&apos;t create</source>
+        <translation>Oluşturma</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="567"/>
+        <source>Create and change the name</source>
+        <translation>Oluştur ve ismi değiştir</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="574"/>
+        <source>Create but change the name only if a name collision would occur</source>
+        <translation>Oluştur ve ismi sadece bir isim çakışması olacaksa değiştir</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="615"/>
+        <source>Use &quot;proc&quot; as an identifying label</source>
+        <translation>Tanımlayıcı etiket olarak &quot;proc&quot; kullan</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="672"/>
+        <source>Use the source dir</source>
+        <translation>Kaynak klasörü kullan</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="679"/>
+        <source>Use</source>
+        <translation>Kullan</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="722"/>
+        <location filename="../Config.ui" line="766"/>
+        <source>Temporary files</source>
+        <translation>Geçici dosyalar</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="737"/>
+        <source>Source directory</source>
+        <translation>Kaynak dizin</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="785"/>
+        <location filename="../Config.ui" line="833"/>
+        <source>Create in</source>
+        <translation>Şurada oluştur</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="814"/>
+        <source>Compare files</source>
+        <translation>Dosyaları mukayese et</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="884"/>
+        <source>Ignored notes</source>
+        <translation>Dikkate alınmayan notlar</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="894"/>
+        <source>Custom transformation lists</source>
+        <translation>Kişiselleştirilmiş dönüştürme listeleri</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1311"/>
+        <source>Transformation params</source>
+        <translation>Dönüştürme parametreleri</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1317"/>
+        <source>Locale for text conversion</source>
+        <translation>Metin dönüştürme için yerel ayar</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1358"/>
+        <source>Case transformation</source>
+        <translation>Büyük küçük harf dönüştürmesi</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1367"/>
+        <source>Artists</source>
+        <translation>Sanatçılar</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1400"/>
+        <location filename="../Config.ui" line="2129"/>
+        <location filename="../Config.ui" line="2482"/>
+        <source>Others</source>
+        <translation>Diğerleri</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1433"/>
+        <source>Keep original modification time when changing a file</source>
+        <translation>Bir dosyayı değiştirirken orijinal değiştirme zamanını muhafaza et</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1440"/>
+        <source>Keep a single image for a file</source>
+        <translation>Her bir dosya için tek bir resim sakla</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1461"/>
+        <source>Visible Transformations</source>
+        <translation>Görünür Dönüştürmeler</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1471"/>
+        <source>Quality thresholds</source>
+        <translation>Kalite eşikleri</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1477"/>
+        <source>If the audio bitrate falls below these limits, warnings are generated. For VBR a low bitrate is less of an indicatior of poor quality, because if the signal is simple there&apos;s no need for higher bitrates. </source>
+        <translation>Eğer ses bit oranı bu sınırların altına düşerse, ikazlar oluşturulacaktır. VBR için düşük bit oranı kötü kaliteye daha az işaret eder, çünkü sinyal basitse daha yüksek bit oranlarına ihtiyaç olmaz. </translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1490"/>
+        <source>The bitrate is not the best quality indicator. Values from a &quot;Lame header&quot; (if present) are generally better, but these headers are not processed in the current version.</source>
+        <translation>Bit oranı en iyi kalite göstergesi değildir. Lame başlığı&quot; değerleri (mevcutsa) genelde daha iyidir fakat bu başlıklar güncel sürümde işlenmezler.</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1503"/>
+        <source>Note that for mono streams, half of the value for &quot;Dual Channel&quot; is used.</source>
+        <translation>Mono akışlar için &quot;Çift kanal&quot; değerinin yarısının kullanılacağını unutmayın.</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1541"/>
+        <source>Stereo CBR</source>
+        <translation>Stereo CBR</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1555"/>
+        <source>Joint Stereo CBR</source>
+        <translation>Birleşik Stereo CBR</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1569"/>
+        <source>Dual Channel CBR</source>
+        <translation>Çift kanal CBR</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1583"/>
+        <source>Stereo VBR</source>
+        <translation>Stereo VBR</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1609"/>
+        <source>Joint Stereo VBR</source>
+        <translation>Birleşik Stereo VBR</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1635"/>
+        <source>Dual Channel VBR</source>
+        <translation>Çift kanal VBR</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1691"/>
+        <source>Colors</source>
+        <translation>Renkler</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1727"/>
+        <source>Audio</source>
+        <translation>Ses</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1756"/>
+        <source>Xing and LAME</source>
+        <translation>Xing ve LAME</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1785"/>
+        <source>VBRI</source>
+        <translation>VBRI</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1814"/>
+        <source>ID3V2</source>
+        <translation>ID3V2</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1843"/>
+        <source>APIC</source>
+        <translation>APIC</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1872"/>
+        <source>ID3V2.3.0</source>
+        <translation>ID3V2.3.0</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1901"/>
+        <source>ID3V2.4.0</source>
+        <translation>ID3V2.4.0</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1955"/>
+        <source>ID3V1</source>
+        <translation>ID3V1</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="1984"/>
+        <source>Broken streams</source>
+        <translation>Hasarlı akışlar</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2013"/>
+        <source>Truncated streams</source>
+        <translation>Kesik akışlar</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2042"/>
+        <source>Unknown streams</source>
+        <translation>Bilinmeyen akışlar</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2071"/>
+        <source>Lyrics</source>
+        <translation>Şarkı sözleri</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2100"/>
+        <source>Ape</source>
+        <translation>Ape</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2160"/>
+        <source>Reset to default colors</source>
+        <translation>Varsayılan renklere sıfırla</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2197"/>
+        <source>Shell</source>
+        <translation>Kabuk</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2205"/>
+        <source>Enable temporary session per folder</source>
+        <translation>Dizin başına geçici oturumu etkinleştir</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2212"/>
+        <source>Enable hidden session per folder</source>
+        <translation>Dizin başına gizli oturumu etkinleştir</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2219"/>
+        <source>Enable visible session per folder</source>
+        <translation>Dizin başına görünür oturumu etkinleştir</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2286"/>
+        <source>ErrorShell</source>
+        <translation>ErrorShell</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2310"/>
+        <source>External tools</source>
+        <translation>Harici araçlar</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2341"/>
+        <source>Name</source>
+        <translation>İsim</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2351"/>
+        <source>Command</source>
+        <translation>Komut</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2361"/>
+        <source>Wait</source>
+        <translation>Bekle</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2374"/>
+        <source>Don&apos;t wait</source>
+        <translation>Bekleme</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2381"/>
+        <source>Wait for external tool to finish, then keep launch window open</source>
+        <translation>Harici aracın bitmesini bekle, ardından başlangıç penceresini açık muhafaza et</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2388"/>
+        <source>Wait for external tool to finish, then close launch window</source>
+        <translation>Harici aracın bitmesini bekle, ardından başlangıç penceresini kapat</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2411"/>
+        <source>Confirm launch</source>
+        <translation>Başlatmayı teyit et</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2421"/>
+        <source>Confirm</source>
+        <translation>Teyit et</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2434"/>
+        <source>Add</source>
+        <translation>Ekle</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2441"/>
+        <source>Update</source>
+        <translation>Güncelle</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2448"/>
+        <source>Delete</source>
+        <translation>Sil</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2455"/>
+        <source>Discard changes</source>
+        <translation>Değişilikleri iptal et</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2488"/>
+        <source>Tag editor</source>
+        <translation>Etiket düzenleyicisi</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2509"/>
+        <source>Warn when the tag editor enters albums with non-sequential track numbers</source>
+        <translation>Etiket düzenleyici, ardışık olmayan parça sayısı bulunduran albümlere girdiğinde ikazda bulun</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2516"/>
+        <source>Warn when pasting track information in the tag editor for albums with non-sequential track numbers</source>
+        <translation>Ardışık olmayan parça sayısı bulunduran albümler için etiket düzenleyicide parça bilgileri yapıştırılırken ikazda bulun</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2523"/>
+        <source>Use &quot;fast save&quot; in the tag editor</source>
+        <translation>Etiket düzenleyicide &quot;hızlı kaydetmeyi&quot; kullan</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2536"/>
+        <source>Maximum image size, in kB</source>
+        <translation>Azami resim boyutu, KB olarak</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2543"/>
+        <source>If an image size is above this value, it will be recompressed before storing it inside MP3 files</source>
+        <translation>Şayet bir resmin boyutu bu değerden yüksekse, MP3 dosyalarına dahil edilmeden evvel tekrar sıkıştırılacaktır</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2589"/>
+        <source>Handle &quot;various artists&quot; for</source>
+        <translation>&quot;Çeşitli sanatçıları&quot; şunlar için yönet:</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2603"/>
+        <source>iTunes</source>
+        <translation>iTunes</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2610"/>
+        <source>Windows Media Player</source>
+        <translation>Windows Media Player</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2662"/>
+        <source>If a field is marked as &quot;assigned&quot; when exiting an album</source>
+        <translation>Şayet bir albümden çıkarken bir alan &quot;atanmış&quot; olarak işaretlenmişse</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2674"/>
+        <location filename="../Config.ui" line="2710"/>
+        <source>Save automatically</source>
+        <translation>Otomatik olarak kaydet</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2681"/>
+        <location filename="../Config.ui" line="2717"/>
+        <source>Discard</source>
+        <translation>İptal et</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2688"/>
+        <location filename="../Config.ui" line="2724"/>
+        <source>Ask</source>
+        <translation>Sor</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2698"/>
+        <source>If a field&apos;s value is different from that in the ID3V2 tag when exiting an album</source>
+        <translation>Bir albümden çıkarken bir alanın değeri ID3V2 etiketinin değerinden farklıysa</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2740"/>
+        <source>Misc</source>
+        <translation>Çeşitli</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2772"/>
+        <source>Scan for new, modified, and deleted files at startup</source>
+        <translation>Başlangıçta yeni, değiştirilmiş ve silinmiş dosyaları ara</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2779"/>
+        <source>Show &quot;Export&quot; button</source>
+        <translation>&quot;Dışa aktar&quot; düğmesini göster</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2786"/>
+        <source>Show &quot;Debug&quot; button</source>
+        <translation>&quot;Hata ayıklama&quot; düğmesini göster</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2793"/>
+        <source>Show &quot;Sessions&quot; button</source>
+        <translation>&quot;Oturumlar&quot; düğmesini göster</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2800"/>
+        <source>Show Gnome 3 close buttons</source>
+        <translation>GNOME 3 kapatma düğmelerini göster</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2807"/>
+        <source>Log program state to &quot;_trace&quot; and &quot;_step&quot; files</source>
+        <translation>Programın durumunu &quot;_trace&quot; ve &quot;_step&quot; dosyalarına kütükle</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2814"/>
+        <source>Check for new version at startup</source>
+        <translation>Başlangıçta yeni bir sürümün mevcut olup olmadığını kontrol et</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2867"/>
+        <source>Language</source>
+        <translation>Lisan</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2893"/>
+        <source>General font:</source>
+        <translation>Genel yazı tipi:</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2906"/>
+        <location filename="../Config.ui" line="2947"/>
+        <source>TextLabel</source>
+        <translation>TextLabel</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2913"/>
+        <location filename="../Config.ui" line="2954"/>
+        <source>Change ...</source>
+        <translation>Değiştir ...</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2920"/>
+        <source>Label font smaller by:</source>
+        <translation>Etiket yazı tipi şu oranda küçültüldü:</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2934"/>
+        <source>Fixed font:</source>
+        <translation>Sabit genişlikli yazı tipi:</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="2988"/>
+        <source>Icon size</source>
+        <translation>İkon boyutu</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="3008"/>
+        <source>Auto-size icons based on the width of the main window</source>
+        <translation>İkonları ana pencerenin genişliğine göre otomatik olarak yeniden boyutlandır</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="3046"/>
+        <source>Normalizer</source>
+        <translation>Normalleştirici</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="3061"/>
+        <source>Command (file names will get added at the end)</source>
+        <translation>Komut (dosya isimleri sonunda eklenir)</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="3074"/>
+        <source>Keep the window open after completion</source>
+        <translation>Tamamlandığında pencereyi açık tut</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="3090"/>
+        <source>File renamer</source>
+        <translation>Dosya yeniden isimlendirici</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="3099"/>
+        <source>Invalid characters</source>
+        <translation>Geçersiz karakterler</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="3109"/>
+        <source>Replace with</source>
+        <translation>Yerine şunu koy:</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="3173"/>
+        <source>O&amp;K</source>
+        <translation>T&amp;amam</translation>
+    </message>
+    <message>
+        <location filename="../Config.ui" line="3180"/>
+        <source>Cancel</source>
+        <translation>İptal et</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigDlgImpl</name>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="279"/>
+        <source>&lt;all notes&gt;</source>
+        <translation>&lt;tüm notlar&gt;</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="409"/>
+        <source>If you don&apos;t know exactly what codepage you want, it&apos;s better to make current a file having an ID3V2 tag that contains text frames using the Latin-1 encoding and having non-ASCII characters. Then the content of those frames will replace this text, allowing you to decide which codepage is a match for your file. ID3V1 tags are supported as well, if you want to copy data from them to ID3V2.</source>
+        <translation>Şayet hangi kod sayfasını istediğinizi tam olara bilmiyorsanız, Latin-1 kodlamasını kullanan ve ASCII olmayan karakterler içeren metin çerçeveleri barındıran ve ID3V2 etiketi içeren bir dosya oluşturmak daha iyidir. Böylece bu çerçevelerin içeriği mevcut metni değiştirecek ve dosyanız için hangi kod sayfasının uygun olduğuna karar vermenizi sağlayacaktır. ID3V1 etiketleri de desteklenmektedir; bu etiketlerden verileri ID3V2&apos;ye kopyalamak isterseniz bu etiketleri de kullanabilirsiniz.</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="488"/>
+        <source>Other notes</source>
+        <translation>Diğer notlar</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="489"/>
+        <source>Ignore notes</source>
+        <translation>Notları dikkate alma</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="571"/>
+        <source>lower case</source>
+        <translation>küçük harfler</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="572"/>
+        <source>UPPER CASE</source>
+        <translation>BÜYÜK HARFLER</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="573"/>
+        <source>Title Case</source>
+        <translation>Başlık için büyük veya küçük harf kullanımı</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="574"/>
+        <source>Sentence case</source>
+        <translation>Cümleler için büyük veya küçük harf kullanımı</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="689"/>
+        <source>Invisible transformations</source>
+        <translation>Görünmeyen dönüştürmeler</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="690"/>
+        <source>Visible transformations</source>
+        <translation>Görünür dönüştürmeler</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="703"/>
+        <source>Characters in this list get replaced with the string below, in &quot;Replace with&quot;
+
+An underlined font is used to allow spaces to be seen</source>
+        <translation>Bu listenin karakterlerinin yerine aşağıdaki dize konacaktır, &quot;Yerine Koy&quot; içindeki
+
+Altı çizili bir yazı tipi, boşlukların görünmesine izin vermek için kullanılır</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="705"/>
+        <source>This string replaces invalid characters in the file renamer&quot;
+
+An underlined font is used to allow spaces to be seen</source>
+        <translation>Bu dize, dosya yeniden isimlendiricideki geçersiz karakterlerin yerine konur
+
+Altı çizili bir yazı tipi, boşlukların görünmesine izin vermek için kullanılır</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="982"/>
+        <source>All transformations</source>
+        <translation>Tüm dönüştürmeler</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="983"/>
+        <source>Used transformations</source>
+        <translation>Kullanılan dönüştürmeler</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1027"/>
+        <source>Confirm</source>
+        <translation>Teyit et</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1027"/>
+        <source>You modified the external tool information but you didn&apos;t save your changes. Discard the changes or cancel closing of the options window?</source>
+        <translation>Harici araç bilgisini değiştirdiniz fakat değişikliklerinizi kaydetmediniz. Değişiklikler mi dikkate alınmasın, yoksa seçenekler penceresinin kapatılması mı iptal edilsin?</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1027"/>
+        <source>&amp;Discard</source>
+        <translation>&amp;Dikkate alma</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1027"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;İptal et</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1042"/>
+        <source>Error</source>
+        <translation>Hata</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1042"/>
+        <source>You can&apos;t have &apos;%1&apos; in both the list of invalid characters and the string that invalid characters are replaced with.</source>
+        <translation>&apos;%1&apos;, hem geçersiz karakterler listesinde hem de onların yerinde geçecek dizede bulunamaz.</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1143"/>
+        <source>Info</source>
+        <translation>Bilgi</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1143"/>
+        <source>You need to restart the program to use the new language.</source>
+        <translation>Yeni dilin kullanılması için programı tekrar başlatmanız gerekir.</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1161"/>
+        <source>Invalid folder name</source>
+        <translation>Geçersiz dizin ismi</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1161"/>
+        <source>A folder name is incorrect.</source>
+        <translation>Bir dizin ismi yanlış.</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1227"/>
+        <source>Add selected note(s)</source>
+        <translation>Seçili notları ilave et</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1228"/>
+        <source>Remove selected note(s)</source>
+        <translation>Seçili notları kaldır</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1229"/>
+        <source>Add all notes</source>
+        <translation>Tüm notları ekle</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1230"/>
+        <source>Remove all notes</source>
+        <translation>Tüm notları kaldır</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1231"/>
+        <source>Restore lists to their default value</source>
+        <translation>Listeleri varsayılan değerlerine sıfırla</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1232"/>
+        <source>Restore lists to the configuration they had when the window was open</source>
+        <translation>Listeleri, pencere açıkken mevcut olan yapılandırmaya geri getir</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1259"/>
+        <source>Select folder</source>
+        <translation>Dizin seç</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1259"/>
+        <source>All files</source>
+        <translation>Tüm dosyalar</translation>
+    </message>
+</context>
+<context>
+    <name>CustomTransfListPainter</name>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="81"/>
+        <source>Action</source>
+        <translation>Eylem</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="81"/>
+        <source>Description</source>
+        <translation>Tanımlama</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="122"/>
+        <source>Add selected transformation(s)</source>
+        <translation>Seçili dönüştürmeleri ekle</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="123"/>
+        <source>Remove selected transformation(s)</source>
+        <translation>Seçili dönüştürmeleri kaldır</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="126"/>
+        <source>Restore current list to its default value</source>
+        <translation>Güncel listeyi varsayılan değerine sıfırla</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="127"/>
+        <source>Restore current list to the configuration it had when the window was open</source>
+        <translation>Listeyi, pencere açıkken mevcut olan yapılandırmaya geri al</translation>
+    </message>
+</context>
+<context>
+    <name>DataStream</name>
+    <message>
+        <location filename="../DataStream.cpp" line="74"/>
+        <source>begins with: </source>
+        <translation>şununla başlar: </translation>
+    </message>
+    <message>
+        <location filename="../DataStream.cpp" line="224"/>
+        <source>Broken %1</source>
+        <translation>Hasarlı %1</translation>
+    </message>
+    <message>
+        <location filename="../DataStream.cpp" line="246"/>
+        <source>Unsupported %1</source>
+        <translation>Desteklenmeyen %1</translation>
+    </message>
+    <message>
+        <location filename="../DataStream.h" line="183"/>
+        <source>Unknown</source>
+        <translation>Bilinmiyor</translation>
+    </message>
+    <message>
+        <location filename="../DataStream.h" line="277"/>
+        <source>Truncated MPEG</source>
+        <translation>Kesik MPEG</translation>
+    </message>
+    <message>
+        <location filename="../DataStream.h" line="312"/>
+        <source>Null</source>
+        <translation>Boş</translation>
+    </message>
+    <message>
+        <location filename="../DataStream.h" line="346"/>
+        <source>Unreadable</source>
+        <translation>Okunamıyor</translation>
+    </message>
+    <message>
+        <location filename="../MpegFrame.cpp" line="238"/>
+        <source>MPEG-1</source>
+        <translation>MPEG-1</translation>
+    </message>
+    <message>
+        <location filename="../MpegFrame.cpp" line="238"/>
+        <source>MPEG-2</source>
+        <translation>MPEG-2</translation>
+    </message>
+    <message>
+        <location filename="../MpegFrame.cpp" line="238"/>
+        <source>MPEG-2.5</source>
+        <translation>MPEG-2.5</translation>
+    </message>
+    <message>
+        <location filename="../MpegFrame.cpp" line="244"/>
+        <source>Layer I</source>
+        <translation>Layer I</translation>
+    </message>
+    <message>
+        <location filename="../MpegFrame.cpp" line="244"/>
+        <source>Layer II</source>
+        <translation>Layer II</translation>
+    </message>
+    <message>
+        <location filename="../MpegFrame.cpp" line="244"/>
+        <source>Layer III</source>
+        <translation>Layer III</translation>
+    </message>
+    <message>
+        <location filename="../MpegFrame.cpp" line="250"/>
+        <source>Stereo</source>
+        <translation>Stereo</translation>
+    </message>
+    <message>
+        <location filename="../MpegFrame.cpp" line="250"/>
+        <source>Joint stereo</source>
+        <translation>Birleşik stereo</translation>
+    </message>
+    <message>
+        <location filename="../MpegFrame.cpp" line="250"/>
+        <source>Dual channel</source>
+        <translation>Çift kanal</translation>
+    </message>
+    <message>
+        <location filename="../MpegFrame.cpp" line="250"/>
+        <source>Single channel</source>
+        <translation>Tek kanal</translation>
+    </message>
+    <message>
+        <source>Not an MPEG frame. Synch missing.</source>
+        <translation type="vanished">Bir MPEG çerçevesi değil. Eşleşme eksik.</translation>
+    </message>
+    <message>
+        <source>Not an MPEG frame. Unsupported version (2.5).</source>
+        <translation type="vanished">Bir MPEG çerçevesi değil. Desteklenmeyen sürüm (2.5).</translation>
+    </message>
+    <message>
+        <source>Not an MPEG frame. Invalid version.</source>
+        <translation type="vanished">Bir MPEG çerçevesi değil. Geçersiz sürüm.</translation>
+    </message>
+    <message>
+        <source>Not an MPEG frame. Invalid layer.</source>
+        <translation type="vanished">Bir MPEG çerçevesi değil. Geçersiz katman (layer).</translation>
+    </message>
+    <message>
+        <source>Not an MPEG frame. Invalid bitrate.</source>
+        <translation type="vanished">Bir MPEG çerçevesi değil. Geçersiz hız.</translation>
+    </message>
+    <message>
+        <source>Not an MPEG frame. Invalid frequency for MPEG1.</source>
+        <translation type="vanished">Bir MPEG çerçevesi değil. MPEG1 için geçersiz frekans.</translation>
+    </message>
+    <message>
+        <source>Not an MPEG frame. Invalid frequency for MPEG2.</source>
+        <translation type="vanished">Bir MPEG çerçevesi değil. MPEG2 için geçersiz frekans.</translation>
+    </message>
+    <message>
+        <location filename="../Helpers.cpp" line="372"/>
+        <source>%1 %2%3%4%5%6Hz%7%8bps%9CRC=%10%11length %12 (0x%13)%14padding=%15</source>
+        <translation>%1 %2%3%4%5%6Hz%7%8bps%9CRC=%10%11süre %12 (0x%13)%14dolgu=%15</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="700"/>
+        <location filename="../MpegFrame.cpp" line="258"/>
+        <source>padding=</source>
+        <translation>dolgu=</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="700"/>
+        <source>unsynch=</source>
+        <translation>eşleşme bozukluğu=</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="700"/>
+        <source>frames</source>
+        <translation>çerçeve</translation>
+    </message>
+    <message>
+        <location filename="../MpegFrame.cpp" line="257"/>
+        <source>length=</source>
+        <translation>süre=</translation>
+    </message>
+    <message>
+        <location filename="../MpegStream.cpp" line="231"/>
+        <source>frame count=</source>
+        <translation>çerçeve sayısı=</translation>
+    </message>
+    <message>
+        <location filename="../MpegStream.cpp" line="232"/>
+        <source>last frame removed; it was located at 0x%1</source>
+        <translation>son çerçeve kaldırıldı; 0x%1 konumunda bulunuyordu</translation>
+    </message>
+    <message>
+        <location filename="../MpegStream.cpp" line="232"/>
+        <source>last frame located at 0x%1</source>
+        <translation>son çerçeve 0x%1 konumunda bulunuyor</translation>
+    </message>
+    <message>
+        <location filename="../MpegStream.cpp" line="898"/>
+        <source>Xing header info:</source>
+        <translation>Xing başlık bilgileri:</translation>
+    </message>
+    <message>
+        <location filename="../MpegStream.cpp" line="900"/>
+        <source> frame count=</source>
+        <translation> çerçeve sayısı=</translation>
+    </message>
+    <message>
+        <location filename="../MpegStream.cpp" line="901"/>
+        <source> byte count=</source>
+        <translation> bayt sayısı=</translation>
+    </message>
+    <message>
+        <location filename="../MpegStream.cpp" line="902"/>
+        <source> TOC present</source>
+        <translation> TOC mevcut</translation>
+    </message>
+    <message>
+        <location filename="../MpegStream.cpp" line="903"/>
+        <source> quality=</source>
+        <translation> kalite=</translation>
+    </message>
+    <message>
+        <location filename="../MpegStream.h" line="91"/>
+        <source>MPEG Audio</source>
+        <translation>MPEG Ses</translation>
+    </message>
+    <message>
+        <location filename="../MpegStream.h" line="165"/>
+        <source>Xing Header</source>
+        <translation>Xing Başlığı</translation>
+    </message>
+    <message>
+        <location filename="../MpegStream.h" line="225"/>
+        <source>Lame Header</source>
+        <translation>Lame Başlığı</translation>
+    </message>
+    <message>
+        <location filename="../MpegStream.h" line="249"/>
+        <source>VBRI Header</source>
+        <translation>VBRI Başlığı</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="652"/>
+        <source>N/A</source>
+        <translation>Mevcut değil</translation>
+    </message>
+</context>
+<context>
+    <name>DebugDlg</name>
+    <message>
+        <location filename="../Debug.ui" line="14"/>
+        <source>Debug</source>
+        <translation>Hata ayıklama</translation>
+    </message>
+    <message>
+        <location filename="../Debug.ui" line="59"/>
+        <source>Enable tracing</source>
+        <translation>İzlemeyi etkinleştir</translation>
+    </message>
+    <message>
+        <location filename="../Debug.ui" line="81"/>
+        <source>Save trace messages</source>
+        <translation>İzleme mesajlarını kaydet</translation>
+    </message>
+    <message>
+        <location filename="../Debug.ui" line="84"/>
+        <location filename="../Debug.ui" line="257"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../Debug.ui" line="156"/>
+        <source>Decode MPEG Audio frame header</source>
+        <translation>MPEG Ses çerçevesi başlığının kodunu aç</translation>
+    </message>
+    <message>
+        <location filename="../Debug.ui" line="159"/>
+        <source>dec</source>
+        <translation>aç</translation>
+    </message>
+    <message>
+        <location filename="../Debug.ui" line="197"/>
+        <source>Test</source>
+        <translation>Dene</translation>
+    </message>
+    <message>
+        <location filename="../Debug.ui" line="200"/>
+        <source>tst</source>
+        <translation>dene</translation>
+    </message>
+    <message>
+        <location filename="../Debug.ui" line="254"/>
+        <source>Close</source>
+        <translation>Kapat</translation>
+    </message>
+    <message>
+        <location filename="../Debug.ui" line="289"/>
+        <source>Use all notes</source>
+        <translation>Tüm notları kullan</translation>
+    </message>
+    <message>
+        <location filename="../Debug.ui" line="296"/>
+        <source>Log transformations</source>
+        <translation>Dönüşümleri kütüğe kaydet</translation>
+    </message>
+    <message>
+        <location filename="../Debug.ui" line="303"/>
+        <source>Save downloaded data</source>
+        <translation>İndirilen verileri kaydet</translation>
+    </message>
+    <message>
+        <location filename="../Debug.ui" line="326"/>
+        <source>Trace messages:</source>
+        <translation>İzleme mesajları:</translation>
+    </message>
+</context>
+<context>
+    <name>DebugDlgImpl</name>
+    <message>
+        <location filename="../DebugDlgImpl.cpp" line="92"/>
+        <source>If this is checked, ignored notes and trace notes
+are shown in the note list and exported, regardless
+of the &quot;Ignored&quot; settings.
+
+Note that if this is not checked, the trace notes
+are discarded during file scanning, so checking it
+later won&apos;t bring them back. A new scan is needed
+to see them.</source>
+        <comment>this is a multiline tooltip</comment>
+        <translation>Bu şık işaretliyse, dikkate alınmayan notlar ve izleme
+notları &quot;Dikkate alma&quot; ayarı ne olursa olsun notlar 
+listesinde görüntülenir.
+
+Şıkkın işaretli olmadığı zaman izleme notlarının dosya
+analizi esnasında dikkate alınmayacaklarını, yani bu şıkkı
+sonradan işaretlerseniz bunun onları görüntülemeyeceğini
+unutmayın.
+Yeni bir analiz gerekecektir.</translation>
+    </message>
+    <message>
+        <location filename="../DebugDlgImpl.cpp" line="150"/>
+        <source>Choose destination file</source>
+        <translation>Hedef dosyayı seç</translation>
+    </message>
+    <message>
+        <location filename="../DebugDlgImpl.cpp" line="150"/>
+        <source>Text files (*.txt)</source>
+        <translation>Metin dosyaları (*.txt)</translation>
+    </message>
+    <message>
+        <location filename="../DebugDlgImpl.cpp" line="169"/>
+        <source>Decoded MPEG frame header</source>
+        <translation>Kodu açılmış MPEG çerçeve başlığı</translation>
+    </message>
+</context>
+<context>
+    <name>DirFilterDlg</name>
+    <message>
+        <location filename="../DirFilter.ui" line="14"/>
+        <source>Folder filter</source>
+        <translation>Dizin filtresi</translation>
+    </message>
+    <message>
+        <location filename="../DirFilter.ui" line="47"/>
+        <source>OK</source>
+        <translation>TAMAM</translation>
+    </message>
+    <message>
+        <location filename="../DirFilter.ui" line="54"/>
+        <source>Cancel</source>
+        <translation>İptal et</translation>
+    </message>
+</context>
+<context>
+    <name>DirFilterDlgImpl</name>
+    <message>
+        <location filename="../DirFilterDlgImpl.cpp" line="198"/>
+        <source>&lt;all folders&gt;</source>
+        <translation>&lt;tüm dizinler&gt;</translation>
+    </message>
+    <message>
+        <location filename="../DirFilterDlgImpl.cpp" line="212"/>
+        <source>Available folders</source>
+        <translation>Mevcut dizinler</translation>
+    </message>
+    <message>
+        <location filename="../DirFilterDlgImpl.cpp" line="213"/>
+        <source>Include folders</source>
+        <translation>Dosyaları dahil et</translation>
+    </message>
+    <message>
+        <location filename="../DirFilterDlgImpl.cpp" line="300"/>
+        <source>Add selected folders</source>
+        <translation>Seçili dosyaları ekle</translation>
+    </message>
+    <message>
+        <location filename="../DirFilterDlgImpl.cpp" line="301"/>
+        <source>Remove selected folders</source>
+        <translation>Seçili dosyaları kaldır</translation>
+    </message>
+    <message>
+        <location filename="../DirFilterDlgImpl.cpp" line="305"/>
+        <source>Restore lists to the configuration they had when the window was open</source>
+        <translation>Listeleri pencere açıkken mevcut olan yapılandırmaya geri al</translation>
+    </message>
+    <message>
+        <location filename="../DirFilterDlgImpl.cpp" line="92"/>
+        <source>Folder</source>
+        <translation>Dizin</translation>
+    </message>
+</context>
+<context>
+    <name>DiscogsDownloader</name>
+    <message>
+        <location filename="../DiscogsDownloader.cpp" line="569"/>
+        <source>Download album data from Discogs.com</source>
+        <translation>Albüm verilerini Discogs.com&apos;dan indir</translation>
+    </message>
+    <message>
+        <location filename="../DiscogsDownloader.cpp" line="592"/>
+        <source>Genres</source>
+        <translation>Türler</translation>
+    </message>
+    <message>
+        <location filename="../DiscogsDownloader.cpp" line="592"/>
+        <source>Genres, Styles</source>
+        <translation>Türler, Tarzlar</translation>
+    </message>
+    <message>
+        <location filename="../DiscogsDownloader.cpp" line="592"/>
+        <source>Genres (Styles)</source>
+        <translation>Türler (Tarzlar)</translation>
+    </message>
+    <message>
+        <location filename="../DiscogsDownloader.cpp" line="592"/>
+        <source>Styles</source>
+        <translation>Tarzlar</translation>
+    </message>
+</context>
+<context>
+    <name>DoubleListWdg</name>
+    <message>
+        <location filename="../DoubleListWdg.ui" line="14"/>
+        <source>Form</source>
+        <translation>Pencere</translation>
+    </message>
+    <message>
+        <location filename="../DoubleListWdg.ui" line="35"/>
+        <source>Include elems:</source>
+        <translation>Görüntülenen unsurlar:</translation>
+    </message>
+    <message>
+        <location filename="../DoubleListWdg.ui" line="42"/>
+        <source>Available elems:</source>
+        <translation>Mevcut unsurlar:</translation>
+    </message>
+    <message>
+        <location filename="../DoubleListWdg.ui" line="111"/>
+        <source>&lt;</source>
+        <translation>&lt;</translation>
+    </message>
+    <message>
+        <location filename="../DoubleListWdg.ui" line="152"/>
+        <source>&gt;</source>
+        <translation>&gt;</translation>
+    </message>
+    <message>
+        <location filename="../DoubleListWdg.ui" line="244"/>
+        <source>&gt;&gt;</source>
+        <translation>&gt;&gt;</translation>
+    </message>
+    <message>
+        <location filename="../DoubleListWdg.ui" line="292"/>
+        <location filename="../DoubleListWdg.ui" line="327"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+</context>
+<context>
+    <name>ExportDlg</name>
+    <message>
+        <location filename="../Export.ui" line="14"/>
+        <location filename="../Export.ui" line="183"/>
+        <source>Export</source>
+        <translation>Dışa aktar</translation>
+    </message>
+    <message>
+        <location filename="../Export.ui" line="25"/>
+        <source>File name:</source>
+        <translation>Dosya ismi:</translation>
+    </message>
+    <message>
+        <location filename="../Export.ui" line="35"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../Export.ui" line="44"/>
+        <source>Format</source>
+        <translation>Biçim</translation>
+    </message>
+    <message>
+        <location filename="../Export.ui" line="53"/>
+        <source>XML</source>
+        <translation>XML</translation>
+    </message>
+    <message>
+        <location filename="../Export.ui" line="60"/>
+        <source>Text</source>
+        <translation>Metin</translation>
+    </message>
+    <message>
+        <location filename="../Export.ui" line="67"/>
+        <source>M3U</source>
+        <translation>M3U</translation>
+    </message>
+    <message>
+        <location filename="../Export.ui" line="74"/>
+        <source>Remove root:</source>
+        <translation>Kökü kaldır:</translation>
+    </message>
+    <message>
+        <location filename="../Export.ui" line="81"/>
+        <source>When creating an M3U file, this text gets removed from the beginning of the file names.
+Meant to be used for creating M3U files containing relative paths.</source>
+        <translation>M3U dosyasının oluşturulması sırasında bu metin dosya isimlerinin başından kaldırılacaktır.
+Bu, göreli yollar içeren M3U dosyaları oluşturmak için faydalıdır.</translation>
+    </message>
+    <message>
+        <location filename="../Export.ui" line="89"/>
+        <source>Locale:</source>
+        <translation>Yerel ayar:</translation>
+    </message>
+    <message>
+        <location filename="../Export.ui" line="102"/>
+        <source>Files to save</source>
+        <translation>Kaydedilecek dosyalar</translation>
+    </message>
+    <message>
+        <location filename="../Export.ui" line="111"/>
+        <source>Visible files</source>
+        <translation>Görünen dosyalar</translation>
+    </message>
+    <message>
+        <location filename="../Export.ui" line="118"/>
+        <source>Selected files</source>
+        <translation>Seçili dosyalar</translation>
+    </message>
+    <message>
+        <location filename="../Export.ui" line="141"/>
+        <source>Sort by short names</source>
+        <translation>Kısa isimlere göre sırala</translation>
+    </message>
+    <message>
+        <location filename="../Export.ui" line="176"/>
+        <source>Close</source>
+        <translation>Kapat</translation>
+    </message>
+</context>
+<context>
+    <name>ExportDlgImpl</name>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="121"/>
+        <location filename="../ExportDlgImpl.cpp" line="129"/>
+        <location filename="../ExportDlgImpl.cpp" line="136"/>
+        <location filename="../ExportDlgImpl.cpp" line="142"/>
+        <location filename="../ExportDlgImpl.cpp" line="153"/>
+        <location filename="../ExportDlgImpl.cpp" line="204"/>
+        <location filename="../ExportDlgImpl.cpp" line="441"/>
+        <location filename="../ExportDlgImpl.cpp" line="450"/>
+        <source>Error</source>
+        <translation>Hata</translation>
+    </message>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="121"/>
+        <source>The file name cannot be empty. Exiting ...</source>
+        <translation>Dosya ismi boş olamaz. Çıkılıyor ...</translation>
+    </message>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="129"/>
+        <source>You need to specify an absolute file name when exporting to formats other than .m3u. Exiting ...</source>
+        <translation>m3u biçiminden başka bir biçimde dışa aktarırken mutlak bir dosya ismi belirtmeniz gerekir. Çıkılıyor ...</translation>
+    </message>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="136"/>
+        <source>The root cannot be empty if the file name is relative. Exiting ...</source>
+        <translation>Dosya ismi göreliyse kök boş olamaz. Çıkılıyor ...</translation>
+    </message>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="142"/>
+        <source>The root must be an absolute directory name. Exiting ...</source>
+        <translation>Kökün mutlak bir dizin ismi olması gerekir. Çıkılıyor ...</translation>
+    </message>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="153"/>
+        <source>The root doesn&apos;t exist. Exiting ...</source>
+        <translation>Kök mevcut değil. Çıkılıyor ...</translation>
+    </message>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="169"/>
+        <source>Warning</source>
+        <translation>İkaz</translation>
+    </message>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="169"/>
+        <source>A file called &quot;%1&quot; already exists. Do you want to overwrite it?</source>
+        <translation>&quot;%1&quot; isimli bir dosya zaten mevcut. Üzerine yazmak istiyor musunuz?</translation>
+    </message>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="169"/>
+        <source>&amp;Overwrite</source>
+        <translation>&amp;Üzerine yaz</translation>
+    </message>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="169"/>
+        <source>Cancel</source>
+        <translation>İptal et</translation>
+    </message>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="200"/>
+        <source>Info</source>
+        <translation>Bilgi</translation>
+    </message>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="200"/>
+        <source>Successfully created file &quot;%1&quot;</source>
+        <translation>&quot;%1&quot; dosyası başarıyla oluşturuldu</translation>
+    </message>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="200"/>
+        <location filename="../ExportDlgImpl.cpp" line="204"/>
+        <source>O&amp;K</source>
+        <translation>T&amp;amam</translation>
+    </message>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="204"/>
+        <source>There was an error writing to the file &quot;%1&quot;</source>
+        <translation>&quot;%1&quot; dosyasına yazma esnasında bir hata meydana geldi</translation>
+    </message>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="212"/>
+        <source>Choose destination file</source>
+        <translation>Hedef dosyayı seç</translation>
+    </message>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="212"/>
+        <source>XML files (*.xml);;Text files (*.txt);;M3U files (*.m3u)</source>
+        <translation>XML dosyaları (*.xml);;Metin dosyaları (*.txt);;M3U dosyaları (*.m3u)</translation>
+    </message>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="325"/>
+        <source>EWST</source>
+        <comment>the letters are the initials of the 4 severity levels: Error, Warning, Support, Trace</comment>
+        <translation>HUDİ</translation>
+    </message>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="441"/>
+        <source>The file named &quot;%1&quot; isn&apos;t inside the specified root. Exiting ...</source>
+        <translation>&quot;%1&quot; isimli dosya belirtilen kökün içinde değil. Çıkılıyor ...</translation>
+    </message>
+    <message>
+        <location filename="../ExportDlgImpl.cpp" line="450"/>
+        <source>The file named &quot;%1&quot; cannot be encoded in the selected locale. Exiting ...</source>
+        <translation>&quot;%1&quot; isimli dosya seçili yerel ayarla kodlanamaz. Çıkılıyor ...</translation>
+    </message>
+</context>
+<context>
+    <name>ExternalToolDlg</name>
+    <message>
+        <location filename="../ExternalTool.ui" line="14"/>
+        <source>External tool</source>
+        <translation>Harici araç</translation>
+    </message>
+    <message>
+        <location filename="../ExternalTool.ui" line="59"/>
+        <source>Keep window open after completion</source>
+        <translation>Tamamlandığında pencereyi açık tut</translation>
+    </message>
+    <message>
+        <location filename="../ExternalTool.ui" line="66"/>
+        <source>Abort</source>
+        <translation>Durdur</translation>
+    </message>
+    <message>
+        <location filename="../ExternalTool.ui" line="73"/>
+        <source>Close</source>
+        <translation>Kapat</translation>
+    </message>
+</context>
+<context>
+    <name>ExternalToolDlgImpl</name>
+    <message>
+        <location filename="../ExternalToolDlgImpl.cpp" line="189"/>
+        <source>Error</source>
+        <translation>Hata</translation>
+    </message>
+    <message>
+        <location filename="../ExternalToolDlgImpl.cpp" line="189"/>
+        <source>Cannot start process. Check that the executable name and the parameters are correct.</source>
+        <translation>Sürece başlanamaz. Program isminin ve parametrelerin doğru olduklarını kontrol edin.</translation>
+    </message>
+    <message>
+        <location filename="../ExternalToolDlgImpl.cpp" line="289"/>
+        <source>Finished</source>
+        <translation>Tamamlandı</translation>
+    </message>
+    <message>
+        <location filename="../ExternalToolDlgImpl.cpp" line="302"/>
+        <source>Warning</source>
+        <translation>Uyarı</translation>
+    </message>
+    <message>
+        <location filename="../ExternalToolDlgImpl.cpp" line="302"/>
+        <source>Cannot close while &quot;%1&quot; is running.</source>
+        <translation>&quot;%1&quot; çalıştığı sürece kapatılamaz.</translation>
+    </message>
+    <message>
+        <location filename="../ExternalToolDlgImpl.cpp" line="318"/>
+        <source>Confirm</source>
+        <translation>Teyit et</translation>
+    </message>
+    <message>
+        <location filename="../ExternalToolDlgImpl.cpp" line="318"/>
+        <source>Stopping &quot;%1&quot; may leave the files in an inconsistent state or may prevent temporary files from being deleted. Are you sure you want to abort &quot;%1&quot;?</source>
+        <translation>&quot;%1&quot; unsurunun durdurulması dosyaları tutarsız bir durumda bırakabilir veya geçici dosyaların silinmesini engelleyebilir. &quot;%1&quot; unsurunu durdurmak istediğinizden emin misiniz?</translation>
+    </message>
+    <message>
+        <location filename="../ExternalToolDlgImpl.cpp" line="318"/>
+        <source>Yes, abort</source>
+        <translation>Evet, durdur</translation>
+    </message>
+    <message>
+        <location filename="../ExternalToolDlgImpl.cpp" line="318"/>
+        <source>Don&apos;t abort</source>
+        <translation>Durdurma</translation>
+    </message>
+</context>
+<context>
+    <name>ExternalToolsModel</name>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1716"/>
+        <source>Name</source>
+        <translation>İsim</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1717"/>
+        <source>Command</source>
+        <translation>Komut</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1718"/>
+        <source>Wait</source>
+        <translation>Bekle</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="1719"/>
+        <source>Confirm launch</source>
+        <translation>Başlatmayı teyit et</translation>
+    </message>
+</context>
+<context>
+    <name>FileRenamer::HndlrListModel</name>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="127"/>
+        <source>&lt;&lt; missing ID3V2 &gt;&gt;</source>
+        <translation>&lt;&lt; eksik ID3V2 &gt;&gt;</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="135"/>
+        <source>&lt;&lt; no pattern defined &gt;&gt;</source>
+        <translation>&lt;&lt; hiçbir örüntü tanımlanmamış &gt;&gt;</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="143"/>
+        <source>&lt;&lt; missing fields &gt;&gt;</source>
+        <translation>&lt;&lt; eksik alanlar &gt;&gt;</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="197"/>
+        <source>File name</source>
+        <translation>Dosya ismi</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="198"/>
+        <source>New file name</source>
+        <translation>Yeni dosya ismi</translation>
+    </message>
+</context>
+<context>
+    <name>FileRenamerDlg</name>
+    <message>
+        <location filename="../FileRenamer.ui" line="14"/>
+        <source>MP3 Diags - File renamer</source>
+        <translation>MP3 Diags - Dosya yeniden isimlendirici</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamer.ui" line="56"/>
+        <source>Previous [Ctrl+P]</source>
+        <translation>Önceki [Ctrl+P]</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamer.ui" line="59"/>
+        <source>&lt;</source>
+        <translation>&lt;</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamer.ui" line="72"/>
+        <source>Ctrl+P</source>
+        <translation>Ctrl+P</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamer.ui" line="85"/>
+        <source>Folder</source>
+        <translation>Dizin</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamer.ui" line="110"/>
+        <source>Next [Ctrl+N]</source>
+        <translation>Sonraki [Ctrl+N]</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamer.ui" line="113"/>
+        <source>&gt;</source>
+        <translation>&gt;</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamer.ui" line="126"/>
+        <source>Ctrl+N</source>
+        <translation>Ctrl+N</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamer.ui" line="142"/>
+        <source>If this is checked, a copy of the file is created, and both original and copy are kept</source>
+        <translation>Bu şık işaretlendiyse, dosyanın bir kopyası oluşturulur ve hem orijinal, hem de kopya muhafaza edilir</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamer.ui" line="145"/>
+        <source>Keep the original file</source>
+        <translation>Orijinal dosyayı muhafaza et</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamer.ui" line="155"/>
+        <source>Mark unrated as duplicates</source>
+        <translation>Notlandırılmamışları çift olarak işaretle</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamer.ui" line="177"/>
+        <source>Edit patterns</source>
+        <translation>Örüntüleri düzenle</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamer.ui" line="180"/>
+        <location filename="../FileRenamer.ui" line="218"/>
+        <location filename="../FileRenamer.ui" line="256"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamer.ui" line="215"/>
+        <source>Rename</source>
+        <translation>Tekrar isimlendir</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamer.ui" line="253"/>
+        <source>Close</source>
+        <translation>Kapat</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamer.ui" line="288"/>
+        <source>alb type</source>
+        <translation>alb türü</translation>
+    </message>
+</context>
+<context>
+    <name>FileRenamerDlgImpl</name>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="573"/>
+        <source>Source or destination is a directory</source>
+        <translation>Kaynak veya hedef bir dizindir</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="577"/>
+        <source>Error during copying</source>
+        <translation>Kopyalama esnasında hata</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="581"/>
+        <source>Error during renaming</source>
+        <translation>Yeniden isimlendirme esnasında hata</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="585"/>
+        <source>Destination already exists</source>
+        <translation>Hedef zaten mevcut</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="589"/>
+        <source>Source not found</source>
+        <translation>Kaynak bulunamadı</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="593"/>
+        <source>Cannot create folder %1</source>
+        <translation>%1 dizini oluşturulamaz</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="606"/>
+        <source>Unknown error</source>
+        <translation>Bilinmeyen hata</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="633"/>
+        <source>No patterns exist</source>
+        <translation>Hiçbir örüntü mevcut değil</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="633"/>
+        <source>You must create at least a pattern before you can start renaming files.</source>
+        <translation>Dosyaları yeniden isimlendirmeden önce en az bir örüntü oluşturmanız gerekir.</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="668"/>
+        <source>Confirm</source>
+        <translation>Teyit et</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="668"/>
+        <source>Copy all the files?</source>
+        <translation>Tüm dosyalar kopyalansın mı?</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="668"/>
+        <source>Copy the selected files?</source>
+        <translation>Tüm seçili dosyalar kopyalansın mı?</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="668"/>
+        <source>Rename all the files?</source>
+        <translation>Tüm dosyalar yeniden isimlendirilsinler mi?</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="668"/>
+        <source>Rename the selected files?</source>
+        <translation>Tüm seçili dosyalar yeniden isimlendirilsinler mi?</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="668"/>
+        <source>&amp;Yes</source>
+        <translation>&amp;Evet</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="668"/>
+        <source>Cancel</source>
+        <translation>İptal et</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="677"/>
+        <location filename="../FileRenamerDlgImpl.cpp" line="684"/>
+        <location filename="../FileRenamerDlgImpl.cpp" line="690"/>
+        <location filename="../FileRenamerDlgImpl.cpp" line="696"/>
+        <location filename="../FileRenamerDlgImpl.cpp" line="715"/>
+        <source>Error</source>
+        <translation>Hata</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="677"/>
+        <source>Operation aborted because file &quot;%1&quot; doesn&apos;t have an ID3V2 tag.</source>
+        <translation>İşlem, &quot;%1&quot; dosyasının ID3V2 etiketi bulunmadığı için iptal edildi.</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="684"/>
+        <source>Operation aborted because file &quot;%1&quot; is missing some required fields in its ID3V2 tag.</source>
+        <translation>İşlem, &quot;%1&quot; dosyasının ID3V2 etiketinde bazı gerekli alanlar eksik olduğu için iptal edildi.</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="690"/>
+        <source>Operation aborted because it would create 2 copies of a file called &quot;%1&quot;</source>
+        <translation>İşlem, &quot;%1&quot; isimli dosyanın 2 kopyasını oluşturacağı için iptal edildi</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="696"/>
+        <source>Operation aborted because a file called &quot;%1&quot; already exists.</source>
+        <translation>&quot;%1&quot; isimli bir dosya zaten mevcut olduğu için işlem iptal edildi.</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="710"/>
+        <source>Copying all the files in the current album</source>
+        <translation>Güncel albümdeki tüm dosyalar kopyalanıyor</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="710"/>
+        <source>Copying the selected files in the current album</source>
+        <translation>Güncel albümdeki seçili dosyalar kopyalanıyor</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="710"/>
+        <source>Renaming all the files in the current album</source>
+        <translation>Güncel albümdeki tüm dosyalar tekrar isimlendiriliyor</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="710"/>
+        <source>Renaming the selected files in the current album</source>
+        <translation>Güncel albümdeki seçili dosyalar tekrar isimlendiriyor</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="828"/>
+        <source>Single artist</source>
+        <translation>Tek sanatçı</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="828"/>
+        <source>Various artists</source>
+        <translation>Çeşitli sanatçılar</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="864"/>
+        <source>Error setting up patterns</source>
+        <translation>Örüntülerin yapılandırmasında hata</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="864"/>
+        <source>An invalid value was found in the configuration file. You&apos;ll have to set up the patterns manually.</source>
+        <translation>Yapılandırma dosyasında geçersiz bir değere rastlandı. Örüntüleri el ile yapılandırmanız gerekmektedir.</translation>
+    </message>
+</context>
+<context>
+    <name>FilesModel</name>
+    <message>
+        <location filename="../FilesModel.cpp" line="150"/>
+        <source>File name</source>
+        <translation>Dosya ismi</translation>
+    </message>
+</context>
+<context>
+    <name>FixedAddrRemover</name>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="3020"/>
+        <source>Remove stream %1 at address 0x%2</source>
+        <translation>0x%2 adresindeki %1 akışını kaldır</translation>
+    </message>
+</context>
+<context>
+    <name>GlobalTranslHlp</name>
+    <message>
+        <location filename="../CommonTypes.cpp" line="478"/>
+        <source>Don&apos;t wait</source>
+        <translation>Bekleme</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="479"/>
+        <source>Wait for external tool to finish, then close launch window</source>
+        <translation>Harici aracın bitmesini bekle, ardından başlatma penceresini kapat</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="480"/>
+        <source>Wait for external tool to finish, then keep launch window open</source>
+        <translation>Harici aracın bitmesini bekle, ardından başlatma penceresini açık tut</translation>
+    </message>
+    <message>
+        <location filename="../Helpers.cpp" line="1469"/>
+        <source>These settings cannot currently be changed. In order to make changes you should probably run the program as an administrator.</source>
+        <translation>Bu ayarlar şu anda değiştirilemezler. Değişiklik yapmak için programı muhtemelen yönetici olarak başlatmanız gerekir.</translation>
+    </message>
+    <message>
+        <location filename="../Helpers.cpp" line="1546"/>
+        <source>Platform not supported</source>
+        <translation>Desteklenmeyen platform</translation>
+    </message>
+    <message>
+        <location filename="../Helpers.h" line="280"/>
+        <source>yes</source>
+        <translation>evet</translation>
+    </message>
+    <message>
+        <location filename="../Helpers.h" line="280"/>
+        <source>no</source>
+        <translation>hayır</translation>
+    </message>
+    <message>
+        <location filename="../Widgets.cpp" line="150"/>
+        <location filename="../Widgets.cpp" line="155"/>
+        <location filename="../Widgets.cpp" line="160"/>
+        <source>O&amp;K</source>
+        <translation>T&amp;amam</translation>
+    </message>
+</context>
+<context>
+    <name>HtmlMsg</name>
+    <message>
+        <location filename="../Widgets.cpp" line="322"/>
+        <source>I got the message; don&apos;t show this again</source>
+        <translation>Anladım, bunu bir daha gösterme</translation>
+    </message>
+</context>
+<context>
+    <name>Id3V230Frame</name>
+    <message>
+        <location filename="../Id3V230Stream.cpp" line="57"/>
+        <location filename="../Id3V230Stream.cpp" line="109"/>
+        <source>Truncated ID3V2.3.0 tag.</source>
+        <translation>Kesik ID3V2.3.0 etiketi.</translation>
+    </message>
+    <message>
+        <source>Broken ID3V2.3.0 tag.</source>
+        <translation type="vanished">Hasarlı ID3V2.3.0 etiketi.</translation>
+    </message>
+    <message>
+        <location filename="../Id3V230Stream.cpp" line="78"/>
+        <source>ID3V2.3.0 frame with negative size.</source>
+        <translation>Eksi boyutlu ID3V2.3.0 çerçevesi.</translation>
+    </message>
+    <message>
+        <location filename="../Id3V230Stream.cpp" line="79"/>
+        <source>ID3V2.3.0 frame too long.</source>
+        <translation>Çok uzun ID3V2.3.0 çerçevesi.</translation>
+    </message>
+    <message>
+        <location filename="../Id3V230Stream.cpp" line="83"/>
+        <location filename="../Id3V230Stream.cpp" line="87"/>
+        <source>ID3V2.3.0 tag containing a frame with an invalid name: %1.</source>
+        <translation>Geçersiz bir isim içeren çerçeve bulunduran ID3V2.3.0 etiketi: %1.</translation>
+    </message>
+    <message>
+        <location filename="../Id3V230Stream.cpp" line="95"/>
+        <source>ID3V2.3.0 tag containing a frame with an unsupported flag.</source>
+        <translation>Desteklenmeyen bir bayrak içeren bir çerçeve bulunduran ID3V2.3.0 etiketi.</translation>
+    </message>
+    <message>
+        <location filename="../Id3V230Stream.cpp" line="131"/>
+        <location filename="../Id3V230Stream.cpp" line="143"/>
+        <location filename="../Id3V230Stream.cpp" line="150"/>
+        <source>%1 (Frame: %2)</source>
+        <translation>%1 (Çerçeve: %2)</translation>
+    </message>
+    <message>
+        <location filename="../Id3V230Stream.cpp" line="136"/>
+        <source>INVALID</source>
+        <translation>GEÇERSİZ</translation>
+    </message>
+    <message>
+        <location filename="../Id3V230Stream.cpp" line="158"/>
+        <source>ID3V2.3.0 tag containing a broken text frame named %1.</source>
+        <translation>Şu isimde hasarlı metin çerçevesi içeren ID3V2.3.0 etiketi: %1.</translation>
+    </message>
+    <message>
+        <location filename="../Id3V230Stream.cpp" line="162"/>
+        <source>ID3V2.3.0 tag containing a text frame named %1 using unsupported characters.</source>
+        <translation>%1 isimli metin çerçevesi içeren ve desteklenmeyen karakterler bulunduran ID3V2.3.0 etiketi.</translation>
+    </message>
+</context>
+<context>
+    <name>Id3V230Stream</name>
+    <message>
+        <location filename="../Id3V230Stream.cpp" line="285"/>
+        <source>Unsupported version of ID3V2 tag%1</source>
+        <translation>ID3V2 %1 etiketinin desteklenmeyen sürümü</translation>
+    </message>
+    <message>
+        <location filename="../Id3V230Stream.cpp" line="289"/>
+        <source>ID3V2 tag with unsupported flag.</source>
+        <translation>Desteklenmeyen bayrak içeren ID3V2 etiketi.</translation>
+    </message>
+</context>
+<context>
+    <name>Id3V240Frame</name>
+    <message>
+        <location filename="../Id3V240Stream.cpp" line="180"/>
+        <source>Truncated ID3V2.4.0 tag.</source>
+        <translation>Kesik ID3V2.4.0 etiketi.</translation>
+    </message>
+    <message>
+        <location filename="../Id3V240Stream.cpp" line="196"/>
+        <location filename="../Id3V240Stream.cpp" line="200"/>
+        <source>ID3V2.4.0 tag containing a frame with an invalid name: %1.</source>
+        <translation>Geçersiz isim içeren bir çerçeve bulunduran ID3V2.4.0 etiketi: %1.</translation>
+    </message>
+    <message>
+        <location filename="../Id3V240Stream.cpp" line="209"/>
+        <location filename="../Id3V240Stream.cpp" line="210"/>
+        <source>ID3V2.4.0 tag containing a frame with an unsupported flag.</source>
+        <translation>Desteklenmeyen bir bayrak içeren bir çerçeve bulunduran ID3V2.4.0 etiketi.</translation>
+    </message>
+    <message>
+        <location filename="../Id3V240Stream.cpp" line="282"/>
+        <source>Broken ID3V2.4.0 tag.</source>
+        <translation>Hasarlı ID3V2.4.0 etiketi.</translation>
+    </message>
+    <message>
+        <location filename="../Id3V240Stream.cpp" line="303"/>
+        <location filename="../Id3V240Stream.cpp" line="315"/>
+        <source>%1 (Frame: %2)</source>
+        <translation>%1 (Çerçeve: %2)</translation>
+    </message>
+    <message>
+        <location filename="../Id3V240Stream.cpp" line="308"/>
+        <source>INVALID</source>
+        <translation>GEÇERSİZ</translation>
+    </message>
+    <message>
+        <location filename="../Id3V240Stream.cpp" line="322"/>
+        <source>ID3V2.4.0 tag containing a broken text frame named %1.</source>
+        <translation>Şu isimde hasarlı bir metin çerçevesi içeren ID3V2.4.0 etiketi: %1.</translation>
+    </message>
+    <message>
+        <location filename="../Id3V240Stream.cpp" line="326"/>
+        <source>ID3V2.4.0 tag containing a text frame named %1 using unsupported characters or unsupported text encoding.</source>
+        <translation>%1 isimli metin çerçevesi içeren ve desteklenmeyen karakterler veya desteklenmeyen metin kodlaması bulunduran ID3V2.4.0 etiketi.</translation>
+    </message>
+</context>
+<context>
+    <name>Id3V240Stream</name>
+    <message>
+        <location filename="../Id3V240Stream.cpp" line="457"/>
+        <source>ID3V2 tag with unsupported flag.</source>
+        <translation>Desteklenmeyen bir bayrak içeren ID3V2 etiketi.</translation>
+    </message>
+</context>
+<context>
+    <name>Id3V2Frame</name>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="287"/>
+        <source>&lt;&lt; error decoding string &gt;&gt;</source>
+        <translation>&lt;&lt; dizenin kodlamasının açılmasında hata &gt;&gt;</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="292"/>
+        <source>&lt;&lt; unsupported encoding &gt;&gt;</source>
+        <translation>&lt;&lt; desteklenmeyen kodlama &gt;&gt;</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="307"/>
+        <source>size=</source>
+        <translation>boyut=</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="326"/>
+        <source>invalid text encoding</source>
+        <translation>geçersiz metin kodlaması</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="330"/>
+        <source>unsupported text encoding</source>
+        <translation>desteklenmeyen metin kodlaması</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="359"/>
+        <location filename="../Id3V2Stream.cpp" line="368"/>
+        <source>&lt;encoding error&gt;</source>
+        <translation>&lt;kodlama hatası&gt;</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="387"/>
+        <source>invalid data</source>
+        <translation>geçersiz veri</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="394"/>
+        <source>MIME=&quot;%1&quot; File=&quot;%2&quot; Descr=&quot;%3&quot; Binary data size=%4</source>
+        <translation>MIME=&quot;%1&quot; Dosya=&quot;%2&quot; Tanım=&quot;%3&quot; İkili veri boyutu=%4</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="395"/>
+        <source>Begins with: %1</source>
+        <translation>Şununla başlar: %1</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="395"/>
+        <source>Content: %1</source>
+        <translation>İçerik: %1</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="403"/>
+        <source>status=%1</source>
+        <translation>durum=%1</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="419"/>
+        <source>link</source>
+        <translation>bağlantı</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="420"/>
+        <source>non-cover</source>
+        <translation>kapak olmayan</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="421"/>
+        <source>error</source>
+        <translation>hata</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="422"/>
+        <source>cover</source>
+        <translation>kapak</translation>
+    </message>
+</context>
+<context>
+    <name>Id3V2StreamBase</name>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="1459"/>
+        <source>%1 (Frame: %2)</source>
+        <translation>%1 (Çerçeve: %2)</translation>
+    </message>
+</context>
+<context>
+    <name>ImageInfoPanel</name>
+    <message>
+        <location filename="../TagReadPanel.cpp" line="286"/>
+        <source>&lt;error&gt;</source>
+        <translation>&lt;hata&gt;</translation>
+    </message>
+    <message>
+        <location filename="../TagReadPanel.cpp" line="314"/>
+        <source>Click to see larger image</source>
+        <translation>Daha büyük resmi görmek için tıklayın</translation>
+    </message>
+</context>
+<context>
+    <name>ImageInfoPanelWdg</name>
+    <message>
+        <location filename="../ImageInfoPanel.ui" line="20"/>
+        <source>Form</source>
+        <translation>Pencere</translation>
+    </message>
+    <message>
+        <location filename="../ImageInfoPanel.ui" line="47"/>
+        <source>Thumb</source>
+        <translation>Ön izleme</translation>
+    </message>
+    <message>
+        <location filename="../ImageInfoPanel.ui" line="63"/>
+        <source>Pos</source>
+        <translation>Konum</translation>
+    </message>
+    <message>
+        <location filename="../ImageInfoPanel.ui" line="70"/>
+        <source>Dim</source>
+        <translation>Ölçü</translation>
+    </message>
+    <message>
+        <location filename="../ImageInfoPanel.ui" line="77"/>
+        <source>Size</source>
+        <translation>Boyut</translation>
+    </message>
+    <message>
+        <location filename="../ImageInfoPanel.ui" line="109"/>
+        <source>View full-size image</source>
+        <translation>Tam boyutlu resmi görüntüle</translation>
+    </message>
+    <message>
+        <location filename="../ImageInfoPanel.ui" line="112"/>
+        <location filename="../ImageInfoPanel.ui" line="162"/>
+        <location filename="../ImageInfoPanel.ui" line="197"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../ImageInfoPanel.ui" line="159"/>
+        <source>Assign picture to songs</source>
+        <translation>Resmi şarkılara ata</translation>
+    </message>
+    <message>
+        <location filename="../ImageInfoPanel.ui" line="194"/>
+        <source>Erase local file</source>
+        <translation>Yerel dosyayı sil</translation>
+    </message>
+</context>
+<context>
+    <name>ImageInfoPanelWdgImpl</name>
+    <message>
+        <location filename="../ImageInfoPanelWdgImpl.cpp" line="60"/>
+        <source>Erase these files:</source>
+        <translation>Şu dosyaları sil:</translation>
+    </message>
+    <message>
+        <location filename="../ImageInfoPanelWdgImpl.cpp" line="68"/>
+        <source>Erase file %1</source>
+        <translation>%1 dosyasını sil</translation>
+    </message>
+</context>
+<context>
+    <name>InvalidPattern</name>
+    <message>
+        <location filename="../FileRenamerDlgImpl.h" line="215"/>
+        <source>Pattern &quot;%1&quot; is invalid. %2</source>
+        <translation>&quot;%1&quot; örüntüsü geçersiz. %2</translation>
+    </message>
+</context>
+<context>
+    <name>LogModel</name>
+    <message>
+        <location filename="../LogModel.cpp" line="110"/>
+        <source>Message</source>
+        <translation>Mesaj</translation>
+    </message>
+</context>
+<context>
+    <name>MainFormDlg</name>
+    <message>
+        <location filename="../MainForm.ui" line="20"/>
+        <source>Dialog</source>
+        <translation>Diyalog</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="53"/>
+        <source>Scan folders for MP3 files [Ctrl+S]</source>
+        <translation>Dizinleri MP3 dosyaları için tara [Ctrl+S]</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="56"/>
+        <source>prc</source>
+        <translation>prc</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="69"/>
+        <source>Ctrl+S</source>
+        <translation>Ctrl+S</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="103"/>
+        <source>Close this window and open the Session editor</source>
+        <translation>Bu pencereyi kapat ve bir oturum düzenleyicisi aç</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="106"/>
+        <location filename="../MainForm.ui" line="144"/>
+        <location filename="../MainForm.ui" line="294"/>
+        <location filename="../MainForm.ui" line="703"/>
+        <location filename="../MainForm.ui" line="741"/>
+        <location filename="../MainForm.ui" line="779"/>
+        <location filename="../MainForm.ui" line="817"/>
+        <location filename="../MainForm.ui" line="855"/>
+        <location filename="../MainForm.ui" line="943"/>
+        <location filename="../MainForm.ui" line="984"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="141"/>
+        <source>Export ...</source>
+        <translation>Dışa aktar ...</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="191"/>
+        <source>Filter by notes</source>
+        <translation>Notlara göre filtrele</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="194"/>
+        <source>nflt</source>
+        <translation>nflt</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="235"/>
+        <source>Filter by folders</source>
+        <translation>Dizinlere göre filtrele</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="238"/>
+        <source>dflt</source>
+        <translation>dflt</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="291"/>
+        <source>Show the full list of files (after applying the filters)</source>
+        <translation>Dosyaların tam listesini göster (filtreleri uyguladıktan sonra)</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="338"/>
+        <source>Show one album (i.e. folder) at a time</source>
+        <translation>Her seferinde sadece bir albüm (yani dizin) göster</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="341"/>
+        <source>d</source>
+        <translation>d</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="382"/>
+        <source>Show one song at a time</source>
+        <translation>Her seferinde sadece bir parça göster</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="385"/>
+        <source>f</source>
+        <translation>f</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="441"/>
+        <source>Previous [Ctrl+P]</source>
+        <translation>Önceki [Ctrl+P]</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="444"/>
+        <source>&lt;</source>
+        <translation>&lt;</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="457"/>
+        <source>Ctrl+P</source>
+        <translation>Ctrl+P</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="470"/>
+        <source>Folder</source>
+        <translation>Dizin</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="495"/>
+        <source>Next [Ctrl+N]</source>
+        <translation>Sonraki [Ctrl+N]</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="498"/>
+        <source>&gt;</source>
+        <translation>&gt;</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="511"/>
+        <source>Ctrl+N</source>
+        <translation>Ctrl+N</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="551"/>
+        <source>Apply a single transformation</source>
+        <translation>Tek bir dönüştürme uygula</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="554"/>
+        <source>rep</source>
+        <translation>rep</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="589"/>
+        <source>Apply custom set of transforms #1</source>
+        <translation>Kişisel dönüştürme kümesi #1&apos;i uygula</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="627"/>
+        <source>Apply custom set of transforms #2</source>
+        <translation>Kişisel dönüştürme kümesi #2&apos;yi uygula</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="665"/>
+        <source>Apply custom set of transforms #3</source>
+        <translation>Kişisel dönüştürme kümesi #3&apos;ü uygula</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="738"/>
+        <source>Tag editor</source>
+        <translation>Etiket düzenleyici</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="776"/>
+        <source>Normalize</source>
+        <translation>Normalleştir</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="814"/>
+        <source>Reload</source>
+        <translation>Tekrar yükle</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="852"/>
+        <source>Rename files</source>
+        <translation>Dosyaları tekrar isimlendir</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="902"/>
+        <source>Configuration</source>
+        <translation>Yapılandırma</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="905"/>
+        <source>cfg</source>
+        <translation>cfg</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="940"/>
+        <source>Debug</source>
+        <translation>Hata ayıklama</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="981"/>
+        <source>About</source>
+        <translation>Hakkında</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="1046"/>
+        <location filename="../MainForm.ui" line="1121"/>
+        <source>File info</source>
+        <translation>Dosya bilgisi</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="1059"/>
+        <location filename="../MainForm.ui" line="1157"/>
+        <source>All notes</source>
+        <translation>Tüm notlar</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="1069"/>
+        <location filename="../MainForm.ui" line="1174"/>
+        <source>Tag details</source>
+        <translation>Etiket ayrıntıları</translation>
+    </message>
+    <message>
+        <location filename="../MainForm.ui" line="1107"/>
+        <source>Removable TextLabel</source>
+        <translation>Kaldırılabilir TextLabel</translation>
+    </message>
+</context>
+<context>
+    <name>MainFormDlgImpl</name>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="442"/>
+        <source>Assertion failure</source>
+        <translation>Belirtme başarısızlığı</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="447"/>
+        <source>Plese report this problem to the project&apos;s Issue Tracker at %1</source>
+        <translation>Lütfen bunu projenin %1 konumundaki sorun izleyicisine raporlayın</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="448"/>
+        <source>Please restart the application for instructions about how to report this issue</source>
+        <translation>Bu sorunu nasıl raporlayacağınıza dair talimatlar için lütfen uygulamayı tekrar başlatın</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="451"/>
+        <source>Exit</source>
+        <translation>Çık</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="458"/>
+        <source>Restarting after crash</source>
+        <translation>Çökme sonrası tekrar başlatılıyor</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="548"/>
+        <location filename="../MainFormDlgImpl.cpp" line="1372"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2143"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2269"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2296"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2376"/>
+        <source>Warning</source>
+        <translation>İkaz</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="548"/>
+        <source>Because MP3 Diags changes the content of your MP3 files if asked to, it has a significant destructive potential, especially in cases where the user doesn&apos;t read the documentation and simply expects the program to do other things than what it was designed to do.</source>
+        <translation>MP3 Diags&apos;ın istediğiniz takdirde MP3 dosyalarınızın içeriğini değiştirdiğinden dolayı hatırı sayılır bir yıkıcı potansiyeli bulunmaktadır, bilhassa kullanıcının belgelendirmeyi okumadığı ve programın tasarlandığı şeyler dışında şeyler yapmasını beklediği durumlarda.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="548"/>
+        <source>Therefore, it is highly advisable to back up your files first.</source>
+        <translation>Dolayısıyla önce dosyalarınızın bir yedeklemesini yapmanız hararetle tavsiye edilir.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="548"/>
+        <source>Also, although MP3 Diags is very stable on the developer&apos;s computer, who hasn&apos;t experienced a crash in a long time and never needed to restore MP3 files from a backup, there are several crash reports that haven&apos;t been addressed, as the developer couldn&apos;t reproduce the crashes and those who reported the crashes didn&apos;t answer the developer&apos;s questions that might have helped isolate the problem.</source>
+        <translation>Ayrıca, her ne kadar MP3 Diags uzun süredir hiçbir çökme yaşamayan ve hiçbir zaman MP3 dosyalarını yedeklemeden geri getirme ihtiyacı duymamış olan geliştiricisinin bilgisayarında son derece kararlı olsa dahi, geliştiricinin çökmeleri kendi tarafında tekrarlayamadığı ve bu raporları gönderenlerin sorunu yalıtmaya yardımcı olacak geliştirici sorularını cevaplamadıklarından dolayı çözülmemiş birkaç çökme raporu bulunmaktadır.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="548"/>
+        <location filename="../MainFormDlgImpl.cpp" line="561"/>
+        <location filename="../main.cpp" line="425"/>
+        <location filename="../main.cpp" line="464"/>
+        <source>O&amp;K</source>
+        <translation>T&amp;amam</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="561"/>
+        <source>Note</source>
+        <translation>Not</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="561"/>
+        <source>If you simply left-click, all the visible files get processed. However, it is possible to process only the selected files. To do that, either keep SHIFT pressed down while clicking or use the right button, as described at %1</source>
+        <translation>Sol tuşla tıklarsanız, tüm görünür dosyalar işlenecektir. Ancak sadece seçili dosyaları işlemek mümkündür. Bunu yapmak için ya tıklama yaparken SHIFT tuşunu basılı turun ya da %1 konumunda anlatıldığı üzere sağ tuşu kullanın</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="633"/>
+        <source>An unknown note was found in the configuration. This note is unknown:
+
+%1</source>
+        <translation>Yapılandırmada bilinmeyen bir not bulundu. Bu not bilinmemektedir: 
+
+%1</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="646"/>
+        <source>Unknown notes were found in the configuration. These notes are unknown:
+
+%1</source>
+        <translation>Yapılandırmada bilinmeyen notlar bulundu. Bu notlar bilinmemektedirler: 
+
+%1</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="649"/>
+        <source>Error setting up the &quot;ignored notes&quot; list</source>
+        <translation>&quot;Dikkate alınmayan notlar&quot; listesi ayarlamasında hata</translation>
+    </message>
+    <message>
+        <source>
+
+You may want to check again the list and add any notes that you want to ignore.
+
+(If you didn&apos;t change the settings file manually, this is probably due to a code enhanement that makes some notes no longer needed, and you can safely ignore this message.)</source>
+        <translation type="vanished">
+
+Listeyi tekrar kontrol edip görmezden gelmek istediğiniz notları ekleyebilirsiniz.
+
+(Ayarlar dosyasını el ile değiştirmediyseniz, bu muhtemelen bazı notları artık fuzuli yapan bir kod iyileştirmesinden kaynaklanmaktadır ve bu mesajı güvenli bir şekilde görmezden gelebilirsiniz.)</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="850"/>
+        <source>MP3 Diags is restarting after a crash.</source>
+        <translation>MP3 Diags bir çökmenin ardından tekrar başlıyor.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="854"/>
+        <source>Information in the file %1%5%2 may help identify the cause of the crash so please make it available to the developer by mailing it to %3, by reporting an issue to the project&apos;s Issue Tracker at %4 and attaching the files to the report, or by some other means (like putting it on a file sharing site.)</source>
+        <comment>%1 and %2 are HTML elements</comment>
+        <translation>%1%5%2 dosyasının içerdiği bilgiler çökme kaynağının tespit edilmesine yardımcı olabilir, dolayısıyla o dosyayı geliştiriciye %3 adresine e-posta ile iletmenizi, projenin %4 konumundaki sorun takip sisteminde bir rapor açıp dosyaları rapora eklemenizi veya başka bir şekilde (mesela bir dosya paylaşım sitesine yükleyerek) geliştiriciye ulaştırmanızı rica ederiz</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="862"/>
+        <source>Information in the files %1%5%2 and %1%6%2 may help identify the cause of the crash so please make them available to the developer by mailing them to %3, by reporting an issue to the project&apos;s Issue Tracker at %4 and attaching the files to the report, or by some other means (like putting them on a file sharing site.)</source>
+        <comment>%1 and %2 are HTML elements</comment>
+        <translation>%1%5%2 ve %1%6%2 dosyalarının içerdiği bilgiler çökme kaynağının tespit edilmesine yardımcı olabilir, dolayısıyla o dosyaları geliştiriciye %3 adresine e-posta ile iletmenizi, projenin %4 konumundaki sorun takip sisteminde bir rapor açıp dosyaları rapora eklemenizi veya başka bir şekilde (mesela bir dosya paylaşım sitesine yükleyerek) geliştiriciye ulaştırmanızı rica ederiz</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="871"/>
+        <source>Information in the files %1%5%2, %1%6%2, and %1%7%2 may help identify the cause of the crash so please make them available to the developer by mailing them to %3, by reporting an issue to the project&apos;s Issue Tracker at %4 and attaching the files to the report, or by some other means (like putting them on a file sharing site.)</source>
+        <comment>%1 and %2 are HTML elements</comment>
+        <translation>%1%5%2, %1%6%2 ve %1%7%2 dosyalarının içerdiği bilgiler çökme kaynağının tespit edilmesine yardımcı olabilir, dolayısıyla o dosyaları geliştiriciye %3 adresine e-posta ile iletmenizi, projenin %4 konumundaki sorun takip sisteminde bir rapor açıp dosyaları rapora eklemenizi veya başka bir şekilde (mesela bir dosya paylaşım sitesine yükleyerek) geliştiriciye ulaştırmanızı rica ederiz</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="885"/>
+        <source>These are plain text files, which you can review before sending, if you have privacy concerns.</source>
+        <translation>Bunlar düz metin dosyalarıdır ve mahremiyetle alakalı endişeleriniz varsa onları göndermeden önce gözden geçirebilirsiniz.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="886"/>
+        <source>After getting the files, the developer will probably want to contact you for more details, so please check back on the status of your report.</source>
+        <translation>Dosyaları aldıktan sonra geliştirici muhtemelen daha fazla ayrıntı için sizinle irtibata geçmek isteyecektir, dolayısıyla raporunuzun durumunu ara sıra tekrar kontrol edin.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="887"/>
+        <source>Note that these files &lt;b&gt;will be removed&lt;/b&gt; when you close this window.</source>
+        <translation>Bu dosyaların, bu pencere kapatıldığında &lt;b&gt;silineceklerini&lt;/b&gt; unutmayın.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="890"/>
+        <source>If there is a name of an MP3 file at the end of &lt;b&gt;%1&lt;/b&gt;, that might be a file that consistently causes a crash. Please check if it is so. Then, if confirmed, please make that file available by mailing it to %2 or by putting it on a file sharing site.</source>
+        <translation>Şayet &lt;b&gt;%1&lt;/b&gt; sonunda bir MP3 dosya ismi mevcutsa, bu sürekli olarak çökmeye neden olan bir dosya olabilir. Bunun doğru olup olmadığını kontrol edin. Ardından, teyit ettiyseniz, lütfen bu dosyayı %2 adresine göndererek veya bir dosya paylaşım sitesine yükleyerek geliştiriciye iletin.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="891"/>
+        <source>Please also try to &lt;b&gt;repeat the steps that led to the crash&lt;/b&gt; before reporting the crash, which will probably result in a new set of files being generated; these files are more likely to contain relevant information than the current set of files, because they will also have information on what happened before the crash, while the current files only tell where the crash occured.</source>
+        <translation>Ayrıca çökmeyi raporlamadan evvel lütfen &lt;b&gt;çökmeye sebep olan adımları tekrar etmeyi&lt;/b&gt; deneyin, ki bu muhtemelen yeni bir dosya kümesi oluşturacaktır ve bu dosyaların güncel dosyalardan daha ilgili bilgi içermesi muhtemeldir çünkü çökmeden önce ne olduğu konusunda da bilgi içereceklerdir, halbuki güncel dosyalar sadece çökmenin nerede oluştuğunu içerir.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="894"/>
+        <source>You should include in your report any other details that seem relevant (what might have caused the failure, steps to reproduce it, ...)</source>
+        <translation>Raporunuzda önemli olabilecek ayrıntıları (sorunu neyin oluşturmuş olabileceği, tekrarlamak için atılması gereken adımlar,...) bulundurmanız gerekir</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="894"/>
+        <source>Remove these files and continue</source>
+        <translation>Bu dosyaları kaldır ve devam et</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="898"/>
+        <source>MP3 Diags is restarting after a crash. There was supposed to be some information about what led to the crash in the file &lt;b&gt;%1&lt;/b&gt;, but that file cannot be found. Please report this issue to the project&apos;s Issue Tracker at %2.</source>
+        <translation>MP3 Diags, bir çökme sonrası tekrar başlıyor. &lt;b&gt;%1&lt;/b&gt; dosyasında çökme sebepleri hakkında bilgi bulunması gerekmekteydi fakat o dosya bulunamıyor. Lütfen bunu %2 konumundaki projenin sorun takip sistemine raporlayın.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="899"/>
+        <source>The developer will probably want to contact you for more details, so please check back on the status of your report.&lt;/p&gt;&lt;p style=&quot;margin-bottom:8px; margin-top:1px; &quot;&gt;Make sure to include the data below, as well as any other detail that seems relevant (what might have caused the failure, steps to reproduce it, ...)</source>
+        <translation>Dosyaları aldıktan sonra geliştirici muhtemelen daha fazla ayrıntı için sizinle irtibata geçmek isteyecektir, dolayısıyla raporunuzun durumunu ara sıra tekrar kontrol edin.&lt;/p&gt;&lt;p style=&quot;margin-bottom:8px; margin-top:1px; &quot;&gt;Aşağıdaki verileri ve önemli olabilecek diğer ayrıntıları eklediğinizden emin olun (sorunu neyin oluşturmuş olabileceği, tekrarlamak için atılması gereken adımlar;...)</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="906"/>
+        <source>MP3 Diags is restarting after a crash. To help determine the reason for the crash, the &lt;i&gt;Log program state to _trace and _step files&lt;/i&gt; option has been activated. This logs to 3 files what the program is doing, which might make it slightly slower.</source>
+        <translation>MP3 Diags bir çökme sonrası tekrar başlıyor. Çökme sebebinin tespit edilebilmesi için, &lt;i&gt;programın durumunun _trace ve _step dosyalarında kütüğe alınma&lt;/i&gt; seçeneği etkinleştirilmiştir. Bu, programın ne yaptığını 3 dosyada kütüğe alır, bu da onu biraz yavaşlatabilir.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="906"/>
+        <source>It is recommended to not process more than several thousand MP3 files while this option is turned on. You can turn it off manually, in the configuration dialog, in the &lt;i&gt;Others&lt;/i&gt; tab, but keeping it turned on may provide very useful feedback to the developer, should the program crash again. With this feedback, future versions of MP3 Diags will get closer to being bug free.</source>
+        <translation>Bu seçenek etkinleştirildiğinde birkaç binden fazla MP3 dosyasının işlenmesi tavsiye edilmez. Onu, yapılandırma diyaloğunun &lt;i&gt;Diğerleri&lt;/i&gt; sekmesinde el ile devre dışı bırakabilirsiniz ancak bu seçeneği faal bırakmanız program tekrar çökerse geliştiriciye faydalı geri bildirim sağlayabilir. Bu geri bildirim sayesinde MP3 Diags&apos;in gelecek sürümleri hatasız olmaya daha yaklaşacaktır.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1334"/>
+        <location filename="../MainFormDlgImpl.cpp" line="1357"/>
+        <location filename="../MainFormDlgImpl.cpp" line="1428"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2093"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2521"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2557"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2731"/>
+        <location filename="../MainFormDlgImpl.cpp" line="3452"/>
+        <location filename="../main.cpp" line="425"/>
+        <location filename="../main.cpp" line="464"/>
+        <source>Error</source>
+        <translation>Hata</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1334"/>
+        <source>MP3 Diags crashed while reading song data from the disk. The whole collection will be rescanned.</source>
+        <translation>MP3 Diags, diskten parça verileri okurken çöktü. Bütün koleksiyon tekrar taranacaktır.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1347"/>
+        <source>Loading data</source>
+        <translation>Veriler yükleniyor</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1372"/>
+        <source>It seems that MP3 Diags is restarting after a crash. Your files will be rescanned.
+
+(Since this may take a long time for large collections, you may want to abort the full rescanning and apply a filter to include only the files that you changed since the last time the program closed correctly, then manually rescan only those files.)</source>
+        <translation>MP3 Diags, bir çökmenin ardından tekrar başlıyor gibi görünüyor. Dosyalarınız tekrar taranacaktır.
+
+(Bu işlem büyük koleksiyonlarda uzun sürebileceğinden dolayı tam tekrar taramayı iptal edip sadece programın son doğru kapanışından beri değiştirdiğiniz dosyaları eklemek ve sadece bu dosyaları el ile tekrar taramak isteyebilirsiniz.)</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1420"/>
+        <source>Saving data</source>
+        <translation>Veriler kaydediliyor</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1428"/>
+        <source>An error occured while saving the MP3 information. You will have to scan your files again.
+
+%1</source>
+        <translation>MP3 verileri kaydedilirken bir hata meydana geldi. Dosyalarınızı tekrar taramanız gerekmektedir.
+
+%1</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1738"/>
+        <source>Scanning MP3 files</source>
+        <translation>MP3 dosyaları taranıyor</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2840"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2967"/>
+        <source>Info</source>
+        <translation>Bilgi</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1357"/>
+        <source>An error occured while loading the MP3 information. Your files will be rescanned.
+
+%1</source>
+        <translation>MP3 bilgilerinin yüklenmeleri esnasında bir hata meydana geldi. Dosyalarınız tekrar taranacaktır.
+
+%1</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="649"/>
+        <source>
+
+You may want to check again the list and add any notes that you want to ignore.
+
+(If you didn&apos;t change the settings file manually, this is probably due to a code enhancement that makes some notes no longer needed, and you can safely ignore this message.)</source>
+        <translation>
+
+Listeyi tekrasr kontrol etmek ve dikkate almamak istediğiniz notları eklemek isteyebilirsiniz.
+
+(Eğer yapılandırma dosyasını el ile değiştirmediyseniz bu, muhtemelen bazı notları artık fuzuli kılan bir kod iyileştirmesinden kaynaklanmaktadır ve bu mesajı güvenle görmezden gelebilirsiniz.)</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1755"/>
+        <source>Issues encountered while scanning the requested folders</source>
+        <translation>İstenen dizinlerin taranması esnasında sorunlarla karşılaşıldı</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1755"/>
+        <source>OK</source>
+        <translation>Tamam</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1931"/>
+        <source>Error setting up custom transformations</source>
+        <translation>Kişiselleştirilmiş dönüştürmelerin ayarlanmaları esnasında hata</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1931"/>
+        <source>Couldn&apos;t find a transformation with the name &quot;%1&quot;. The program will proceed, but you should review the custom transformations lists.</source>
+        <translation>&quot;%1&quot; isimli dönüştürme bulunamadı. Program devam edecektir, fakat kişiselleştirilmiş dönüştürme listelerini gözden geçirmelisiniz.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1983"/>
+        <source>Error setting up visible transformations</source>
+        <translation>Görünür dönüştürmelerin ayarlanmaları esnasında hata</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1983"/>
+        <source>Couldn&apos;t find a transformation with the name &quot;%1&quot;. The program will proceed, but you should review the visible transformations list.</source>
+        <translation>&quot;%1&quot; isimli dönüştürme bulunamadı. Program devam edecektir, fakat görünür dönüştürme listesini gözden geçirmelisiniz.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2016"/>
+        <source>Error setting up external tools</source>
+        <translation>Harici araçların yapılandırılmaları esnasında hata</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2016"/>
+        <source>Unable to parse &quot;%1&quot;. The program will proceed, but you should review the external tools list.</source>
+        <translation>&quot;%1&quot; ayrıştırılamadı. Program devam edecektir, fakat harici araçlar listesini gözden geçirmelisiniz.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2093"/>
+        <source>There are no files to normalize.</source>
+        <translation>Normalleştirilecek hiçbir dosya yok.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2102"/>
+        <source>you are requesting to normalize only some of the files</source>
+        <translation>sadece bazı dosyaların normalleştirilmesini istediniz</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2108"/>
+        <source>the &quot;Album&quot; mode is not selected</source>
+        <translation>&quot;Albüm&quot; kipi seçilmemiş</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2116"/>
+        <source>filters are applied</source>
+        <translation>filtreler uygulandı</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2120"/>
+        <source>a filter is applied</source>
+        <translation>bir filtre uygulandı</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2127"/>
+        <source>the normalization will process more than 50 files, which is more than what an album usually has</source>
+        <translation>normalleştirme 50&apos;den fazla dosya işleyecektir, ki bu genelde bir albümde bulunan dosya saysından fazladır</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2136"/>
+        <source>Normalization should process one whole album at a time, so it should only be run in &quot;Album&quot; mode, when no filters are active, and it should be applied to all the files in that album. But in the current case %1.</source>
+        <translation>Normalleştirme her defada sadece tek ve tam bir albümü işlemelidir, yani &quot;Albüm&quot; kipinde, hiçbir filtre faal değilken çalışmalıdır ve bu albümdeki tüm dosyalara uygulanmalıdır. Fakat güncel durumda %1.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2140"/>
+        <source>Normalization should process one whole album at a time, so it should only be run in &quot;Album&quot; mode, when no filters are active, and it should be applied to all the files in that album. But in the current case  there are some issues:
+%1</source>
+        <translation>Normalleştirme her seferinde sadece tam bir albümü işlemelidir, yani sadece hiçbir filtre etkin değilken &quot;Albüm&quot; kipinde çalıştırılmalıdır ve albümdeki tüm dosyalara uygulanmalıdır. Ancak güncel durumda bazı sorunlar vardır:
+%1</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2143"/>
+        <source>Normalize anyway?</source>
+        <translation>Yine de normalleştirilsin mi?</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2143"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2153"/>
+        <source>Normalize</source>
+        <translation>Normalleştir</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2143"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2153"/>
+        <source>Cancel</source>
+        <translation>İptal et</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2153"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2334"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2356"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2417"/>
+        <location filename="../MainFormDlgImpl.cpp" line="3499"/>
+        <source>Confirm</source>
+        <translation>Teyit et</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2153"/>
+        <source>Normalize all the files in the current album? (Note that normalization is done &quot;in place&quot;, by an external program, so it doesn&apos;t care about the transformation settings for original and modified files.)</source>
+        <translation>Güncel albümdeki bütün dosyalar normalleştirilsin mi? (Normalleştirmenin &quot;yerinde&quot;, harici bir program tarafından yapıldığını yani orijinal ve değiştirilmiş dosyalar için dönüştürme ayarlarını dikkate almadığını unutmayın.)</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2269"/>
+        <source>The file list is empty, therefore no transformations can be applied.
+
+Exiting ...</source>
+        <translation>Dosya listesi boş, dolayısıyla hiçbir dönüştürme uygulanamaz.
+
+Çıkılıyor ...</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2281"/>
+        <source>all the files shown in the file list</source>
+        <translation>dosya listesinde gösterilen tüm dosyalar</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2285"/>
+        <source>all %1 files shown in the file list</source>
+        <translation>dosya listesinde gösterilen tüm %1 dosyalar</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2296"/>
+        <source>No file is selected, therefore no transformations can be applied.
+
+Exiting ...</source>
+        <translation>Hiçbir dosya seçilmiş, dolayısıyla hiçbir dönüştürme uygulanamaz.
+
+Çıkılıyor ...</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2305"/>
+        <source>and the other selected file</source>
+        <translation>ve diğer seçili dosya</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2309"/>
+        <source>and the other %1 selected files</source>
+        <translation>ve seçili diğer %1 dosya</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2334"/>
+        <source>&lt;p&gt;Rebuilding VBR data in Xing / LAME headers can destroy gapless playing information, causing albums that are supposed to be gapless to be played with short gaps between tracks.&lt;/p&gt;&lt;p&gt;Note that this shouldn&apos;t matter for regular, non-gapless, albums.&lt;/p&gt;&lt;p&gt;Proceed?&lt;/p&gt;</source>
+        <translation>&lt;p&gt;VBR verilerini Xing / LAME başlıklarında tekrar oluşturmak aralıksız çalma bilgilerini imha edebilir, ki bu aralıksız çalınması beklenen albümlerin parçalar arasında kısa aralıklarla çalınmalarına sebep olabilir.&lt;/p&gt;&lt;p&gt;Bunun olağan, aralıksız olmayan albümler için bir sorun teşkil etmeyeceğini unutmayın.&lt;/p&gt;&lt;p&gt;Devam edilsin mi?&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2356"/>
+        <source>&lt;p&gt;Removing Xing / LAME headers destroys gapless playing information, causing albums that are supposed to be gapless to be played with short gaps between tracks.&lt;/p&gt;&lt;p&gt;Note that this shouldn&apos;t matter for regular, non-gapless, albums.&lt;/p&gt;&lt;p&gt;Proceed?&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Xing / LAME başlıklarının kaldırılmaları aralıksız çalma bilgilerini imha eder, ki bu aralıksız çalınması beklenen albümlerin parçalar arasında kısa aralıklarla çalınmalarına sebep olabilir.&lt;/p&gt;&lt;p&gt;Bunun olağan, aralıksız olmayan albümler için bir sorun teşkil etmeyeceğini unutmayın.&lt;/p&gt;&lt;p&gt;Devam edilsin mi?&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2376"/>
+        <source>The transformation list is empty.
+
+Based on the configuration, it is possible for changes to the files in the list to be performed, even in this case (the files may still be moved, renamed or erased). However, the current settings are to leave the original files unchanged, so currently there&apos;s no point in applying an empty transformation list.
+
+Exiting ...</source>
+        <translation>Dönüştürme listesi boştur.
+
+Yapılandırmaya göre bu durumda bile dosyalara değişiklik uygulanması mümkündür (taşıma, yeniden isimlendirme veya silme). Ancak güncel ayarlar orijinal dosyalara dokunulmaması yönündedir, yani şu anda boş bir dönüştürme listesinin uygulanmasının hiçbir manası yoktur.
+
+Çıkılıyor ...</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2379"/>
+        <source>Apply an empty transformation list to all the files shown in the file list? (Note that even if no transformations are performed, the files may still be moved, renamed or erased, based on the current settings.)</source>
+        <translation>Listede gösterilen üm dosyalara boş bir dönüştürme listesi uygulansın mı? (Her ne kadar hiçbir dönüştürme uygulanmasa dahi, güncel ayarlara dayalı olarak dosyaların taşınabileceklerini, tekrar isimlendirilebileceklerini veya silinebileceklerini unutmayın.)</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2383"/>
+        <source>Apply transformation &quot;%1&quot; to %2?</source>
+        <translation>&quot;%1&quot; dönüştürmesi  %2 unsuruna uygulansın mı?</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2387"/>
+        <source>Apply the following transformations to %1?</source>
+        <translation>%1 unsuruna şu dönüştürmeler uygulansın mı?</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2397"/>
+        <source>don&apos;t change</source>
+        <translation>değiştirme</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2398"/>
+        <source>erase</source>
+        <translation>sil</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2399"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2400"/>
+        <source>move</source>
+        <translation>taşı</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2401"/>
+        <source>rename</source>
+        <translation>yeniden isimlendir</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2402"/>
+        <source>move if destination doesn&apos;t exist</source>
+        <translation>hedef mevcut değilse taşı</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2406"/>
+        <source>Actions to be taken:</source>
+        <translation>Yapılacak eylemler:</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2410"/>
+        <source>original file that has been transformed: %1</source>
+        <translation>dönüştürülen orijinal dosya: %1</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2413"/>
+        <source>original file that has not been transformed: %1</source>
+        <translation>dönüştürülmeyen orijinal dosya: %1</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2334"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2356"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2417"/>
+        <location filename="../MainFormDlgImpl.cpp" line="3499"/>
+        <source>&amp;Yes</source>
+        <translation>&amp;Evet</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2334"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2356"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2417"/>
+        <location filename="../MainFormDlgImpl.cpp" line="3499"/>
+        <source>&amp;No</source>
+        <translation>&amp;Hayır</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2429"/>
+        <source>Applying transformations to MP3 files</source>
+        <translation>Dönüştürmeler MP3 dosyalarına uygulanıyor</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2460"/>
+        <source>Apply custom transformation list #%1
+</source>
+        <translation>Kişiselleştirilmiş dönüştürme listesi #%1 unsurunu uygula
+</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2468"/>
+        <source>   &lt;empty list&gt;
+
+(you can edit the list in the Settings dialog)</source>
+        <translation>   &lt;boş liste&gt;
+
+(listeyi yapılandırma penceresinde düzenleyebilirsiniz)</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2521"/>
+        <source>The file list is empty. You need to populate it before opening the tag editor.</source>
+        <translation>Dosya listesi boştur. Etiket düzenleyicisini açmadan evvel onu doldurmalısınız.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2557"/>
+        <source>The file list is empty. You need to populate it before opening the file rename tool.</source>
+        <translation>Dosya listesi boştur. Dosya yeniden isimlendirme aracını açmadan evvel onu doldurmanız gerekir.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2721"/>
+        <source>Delete %1?</source>
+        <translation>%1 silinsin mi?</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2731"/>
+        <source>Cannot delete file %1</source>
+        <translation>%1 dosyası silinemez</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2841"/>
+        <source>MP3 Diags can check at startup if a new version of the program has been released. Here&apos;s how this is supposed to work:</source>
+        <translation>MP3 Diags, başlangıçta yeni bir sürümün yayınlanmış olup olmadığını kontrol edebilir. Bu, şu şekilde işler:</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2843"/>
+        <source>The check is done in the background, when the program starts, so there should be no performance penalties</source>
+        <translation>Kontrol, program başladığında arka planda yapılır yani performansa kötü etkisi olması beklenmez</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2844"/>
+        <source>A notification message is displayed only if there&apos;s a new version available</source>
+        <translation>Sadece yeni bir sürüm mevcutsa, bir bildirim görüntülenir</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2845"/>
+        <source>The update is manual. You are told that there is a new version and are offered links to see what&apos;s new, but nothing gets downloaded and / or installed automatically</source>
+        <translation>Güncelleme el ile yapılmalıdır. Yeni bir sürümün mevcut olduğu size yenilikleri görmenize izin verecek bağlantılarla bildirilir fakat hiçbir şey otomatik olarak indirilmez ve/veya kurulmaz</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2846"/>
+        <source>There is no System Tray process checking periodically for updates</source>
+        <translation>Belirli aralıklarla güncelleme olup olmadığını kontrol eden bir Sistem Tepsisi süreci yoktur</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2847"/>
+        <source>You can turn the notifications on and off from the configuration dialog</source>
+        <translation>Bildirimleri yapılandırma diyaloğundan etkinleştirebilir veya devre dışı bırakabilirsiniz</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2848"/>
+        <source>If you restart the program within a day after a check, no new check is done</source>
+        <translation>Eğer programı kontrolden sonra bir günden az bir süre içinde tekrar başlatırsanız yeni bir kontrol yapılmayacaktır</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2856"/>
+        <location filename="../MainFormDlgImpl.cpp" line="2968"/>
+        <source>Disable checking for new versions</source>
+        <translation>Yeni sürüm bulunup bulunmadığı kontrolünü devre dışı bırak</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2856"/>
+        <source>Enable checking for new versions</source>
+        <translation>Yeni sürüm bulunup bulunmadığı kontrolünü etkinleştir</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2944"/>
+        <source>Version %1 has been published. You are running %2. You can see what&apos;s new in %3. A more technical list with changes can be seen in %4.</source>
+        <translation>%1 sürümü yayınlanmıştır. Çalıştırdığınız sürüm %2. Yenilikleri %3 konumunda görebilirsiniz. Değişiklikleri içeren daha teknik bir liste %4 konumunda görülebilir.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2948"/>
+        <source>the %1MP3 Diags blog%2</source>
+        <comment>arguments are HTML elements</comment>
+        <translation>%1MP3 Diags günlüğü%2</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2952"/>
+        <source>the %1change log%2</source>
+        <comment>arguments are HTML elements</comment>
+        <translation>%1değişiklikler kütüğü%2</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2959"/>
+        <source>This notification is about the availability of the source code. Binaries may or may not be available at this time, depending on your particular platform.</source>
+        <translation>Bu bildirim, kaynak kodun mevcudiyeti ile alakalıdır. Platformunuza göre derlenmiş sürümler henüz mevcut olmayabilirler.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2962"/>
+        <source>You should review the changes and decide if you want to upgrade or not.</source>
+        <translation>Değişiklikleri gözden geçirip güncelleme yapma isteyip istemediğinize karar vermelisiniz.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2963"/>
+        <source>Note: if you want to upgrade, you should %1close MP3 Diags%2 first.</source>
+        <comment>arguments are HTML elements</comment>
+        <translation>Not: güncelleme yapma istiyorsanız, önce %1MP3 Diags uygulamasını kapatmalısınız%2.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2964"/>
+        <source>Choose what do you want to do:</source>
+        <translation>Ne yapmak istediğinizi seçin:</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2968"/>
+        <source>Just close this message</source>
+        <translation>Sadece bu mesajı kapat</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2968"/>
+        <source>Don&apos;t tell me about version %1 again</source>
+        <translation>Bir daha bana %1 sürümünden bahsetme</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="3377"/>
+        <source>Open containing folder ...</source>
+        <translation>İçeren dizini açın ...</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="3423"/>
+        <source>Run &quot;%1&quot; on %2?</source>
+        <translation>&quot;%1&quot; unsuru %2 üzerinde çalıştırılsın mı?</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="3452"/>
+        <source>Cannot start process. Check that the executable name and the parameters are correct.</source>
+        <translation>Süreç başlatılamaz. Çalıştırılabilir dosya ismi ve parametrelerin doğru olduklarını kontrol edin.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="3488"/>
+        <source>%1 and %2</source>
+        <translation>%1 ve %2</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="3492"/>
+        <source>%1, %2 and %3</source>
+        <translation>%1, %2 ve %3</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="3496"/>
+        <source>%1, %2 and %3 other files</source>
+        <translation>%1, %2 ve %3 başka dosya</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="425"/>
+        <source>Folder &quot;%1&quot; doesn&apos;t exist. The program will exit ...</source>
+        <translation>&quot;%1&quot; dizini mevcut değil. Programdan çıkılacaktır ...</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="464"/>
+        <source>Cannot write to file &quot;%1&quot;. The program will exit ...</source>
+        <translation>&quot;%1&quot; dosyasına yazılamaz. Programdan çıkılacaktır...</translation>
+    </message>
+</context>
+<context>
+    <name>Mp3ProcThread</name>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1694"/>
+        <source>File not found: %1</source>
+        <translation>Dosya bulunamadı: %1</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1697"/>
+        <source>Cannot open file: %1, which seems to be under a folder that is a shortcut. Note that folder shortcuts are not supported, but you can use symbolic links instead.</source>
+        <translation>Dosya açılamaz: %1, ki bu dosya bir kısayol olan bir dizinin altında gibi görünüyor. Dizin kısayollarının desteklenmediğini, bunun yerine sembolik bağlantılar kullanabileceğinizi unutmayın.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1706"/>
+        <source>File name too long: %1</source>
+        <translation>Dosya ismi çok uzun: %1</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1710"/>
+        <source>Scan exception for file: %1: %2</source>
+        <translation>%1 dosyası için tarama istisnası: %2</translation>
+    </message>
+</context>
+<context>
+    <name>Mp3Transformer</name>
+    <message>
+        <location filename="../Mp3TransformThread.cpp" line="725"/>
+        <source>Error</source>
+        <translation>Hata</translation>
+    </message>
+    <message>
+        <location filename="../Mp3TransformThread.cpp" line="737"/>
+        <source>There was an error processing the following file:
+
+%1
+
+%2
+
+Processing aborted.</source>
+        <translation>Şu dosyanın işlenmesi esnasında bir hata meydana geldi:
+
+%1
+
+%2
+
+İşleyiş iptal edildi.</translation>
+    </message>
+    <message>
+        <location filename="../Mp3TransformThread.cpp" line="743"/>
+        <source>There was an error writing to the following file:
+
+%1
+
+Make sure that you have write permissions and that there is enough space on the disk.
+
+Processing aborted.</source>
+        <translation>Şu dosyanın yazılması esnasında bir hata meydana geldi:
+
+%1
+
+Yazma izninizin olduğundan ve diskte yeteri kadar boş alan olduğundan emin olun.
+
+İşleyiş iptal edildi.</translation>
+    </message>
+    <message>
+        <location filename="../Mp3TransformThread.cpp" line="749"/>
+        <source>The file &quot;%1&quot; seems to have been modified since the last scan. You need to rescan it before continuing.
+
+Processing aborted.</source>
+        <translation>&quot;%1&quot; dosyası son taramadan beri değiştirilmiş gibi görünüyor. Devam etmek için onu tekrar taramanız gerekmektedir.
+
+İşleyiş iptal edildi.</translation>
+    </message>
+    <message>
+        <location filename="../Mp3TransformThread.cpp" line="755"/>
+        <source>There was an error processing the following file:
+
+%1
+
+Probably the file was deleted or modified since the last scan, in which case you should reload / rescan your collection. Or it may be used by another program; if that&apos;s the case, you should stop the other program first.
+
+This may also be caused by access restrictions or a full disk.
+
+Processing aborted.</source>
+        <translation>Şu dosyanın işlenmesi esnasında bir hata meydana geldi:
+
+%1
+
+Son taramadan beri dosya muhtemelen değiştirilmiş veya silinmiştir, bu durumda koleksiyonunuzu tekrar yüklemeniz / yeniden taramanız gerekir. Veya başka bir program tarafından kullanılıyor olabilir, bu durumda önce bu diğer programı durdurmanız icap eder.
+
+Bu, aynı zamanda erişim kıstlamalarından veya dolu bir diskten kaynaklanabilir.
+
+İşleyiş iptal edildi.</translation>
+    </message>
+    <message>
+        <location filename="../Mp3TransformThread.cpp" line="759"/>
+        <source>There was an error processing the following file:
+%1
+
+The following folder couldn&apos;t be created:
+
+%2
+
+Processing aborted.</source>
+        <translation>Şu dosyanın işlenmesi esnasında bir hata meydana geldi:
+%1
+
+Şu dizin oluşturulamadı:
+%2
+
+İşleyiş iptal edildi.</translation>
+    </message>
+</context>
+<context>
+    <name>MusicBrainzDownloader</name>
+    <message>
+        <location filename="../MusicBrainzDownloader.cpp" line="83"/>
+        <location filename="../MusicBrainzDownloader.cpp" line="189"/>
+        <source>JSON parse error: %1</source>
+        <translation>JSON ayrıştırma hatası: %1</translation>
+    </message>
+    <message>
+        <location filename="../MusicBrainzDownloader.cpp" line="481"/>
+        <source>Download album data from MusicBrainz.org</source>
+        <translation>Albüm verilerini MusicBrainz.org konumundan indir</translation>
+    </message>
+    <message>
+        <location filename="../MusicBrainzDownloader.cpp" line="594"/>
+        <source>waiting %1ms</source>
+        <translation>%1ms bekleniyor</translation>
+    </message>
+    <message>
+        <location filename="../MusicBrainzDownloader.cpp" line="746"/>
+        <source>&lt;a href=&quot;%1&quot;&gt;view at %2&lt;/a&gt;</source>
+        <translation>&lt;a href=&quot;%1&quot;&gt;%2 konumunda görüntüleyin&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;a href=&quot;%1&quot;&gt;view at amazon.com&lt;/a&gt;</source>
+        <translation type="vanished">&lt;a href=&quot;%1&quot;&gt;amazon.com konumunda görüntüle&lt;/a&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>Note</name>
+    <message>
+        <location filename="../Notes.h" line="192"/>
+        <source>Two MPEG audio streams found, but a file should have exactly one.</source>
+        <translation>İki MPEG akışı tespit edildi, ancak bir dosya tam olarak tek bir akışa sahip olabilir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="193"/>
+        <source>Low quality MPEG audio stream. (What is considered &quot;low quality&quot; can be changed in the configuration dialog, under &quot;Quality thresholds&quot;.)</source>
+        <translation>Düşük kaliteli MPEG akışı (&quot;Düşük kalite&quot; olarak neyin kabul edileceği yapılandırma diyaloğundaki &quot;Kalite eşikleri&quot; kapsamında değiştirilebilir.)</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="194"/>
+        <source>No MPEG audio stream found.</source>
+        <translation>Hiçbir MPEG ses akışı bulunamadı.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="195"/>
+        <source>VBR with audio streams other than MPEG1 Layer III might work incorrectly.</source>
+        <translation>MPEG1 Layer III dışındaki VBR ses akışları yanlış çalışabilir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="196"/>
+        <source>Incomplete MPEG frame at the end of an MPEG stream.</source>
+        <translation>MPEG akışının sonunda tamamlanmamış bir MPEG çerçevesi.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="197"/>
+        <source>Valid frame with a different version found after an MPEG stream.</source>
+        <translation>Bir MPEG akışından sonra başka sürümlü, geçerli bir çerçeve bulundu.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="198"/>
+        <source>Valid frame with a different layer found after an MPEG stream.</source>
+        <translation>Bir MPEG akışından sonra geçerli ama değişik bir layer (katmanlı) çerçeve bulundu.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="199"/>
+        <source>Valid frame with a different channel mode found after an MPEG stream.</source>
+        <translation>Bir MPEG akışından sonra geçerli ama farklı bir kanal kipinde çerçeve bulundu.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="200"/>
+        <source>Valid frame with a different frequency found after an MPEG stream.</source>
+        <translation>Bir MPEG akışından sonra geçerli ama farklı bir frekansı olan bir çerçeve bulundu.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="201"/>
+        <source>Valid frame with a different CRC policy found after an MPEG stream.</source>
+        <translation>Bir MPEG akışından sonra geçerli ama farklı bir CRC politikası olan bir çerçeve bulundu.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="202"/>
+        <source>Invalid MPEG stream. Stream has fewer than 10 frames.</source>
+        <translation>Geçersiz MPEG akışı. Akış, 10&apos;dan az çerçeve barındırmaktadır.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="203"/>
+        <source>Invalid MPEG stream. First frame has different bitrate than the rest.</source>
+        <translation>Geçersiz MPEG akışı. İlk çerçevenin bit hızı diğerlerinden farklıdır.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="204"/>
+        <source>No normalization undo information found. The song is probably not normalized by MP3Gain or a similar program. As a result, it may sound too loud or too quiet when compared to songs from other albums.</source>
+        <translation>Normalleştirmeyi geri almak için hiçbir veri bulunamadı. Şarkı, muhtemelen MP3Gain veya benzer bir program tarafından normalleştirilmemiştir. Bunun sonucu olarak, diğer albümlerin şarkılarıyla karşılaştırıldığında sesi çok yüksek veya çok düşük olabilir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="205"/>
+        <source>Found audio stream in an encoding other than &quot;MPEG-1 Layer 3&quot; or &quot;MPEG-2 Layer 3.&quot; While MP3 Diags understands such streams, very few tests were run on files containing them (because they are not supposed to be found inside files with the &quot;.mp3&quot; extension), so there is a bigger chance of something going wrong while processing them.</source>
+        <translation>&quot;MPEG 1 Layer 3&quot; veya &quot;MPEG 2 Layer 3&quot; kodlamasından farklı kodlamalı bir ses akışı bulundu. MP3 Diags böyle akışları anlasa dahi, bunları içeren dosyalar ile çok az deneme yapılmıştır (çünkü &quot;.mp3&quot; uzantısını kullanan dosyalar içinde bulunmaları beklenmez), yani onları işlerken bir şeylerin yolunda gitmemesi ihtimali daha yüksektir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="208"/>
+        <source>Two Lame headers found, but a file should have at most one of them.</source>
+        <translation>İki Lame başlığı bulundu, ancak bir dosyanın bunlardan sadece bir başlık bulundurması beklenir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="209"/>
+        <source>Xing header seems added by Mp3Fixer, which makes the first frame unusable and causes a 16-byte unknown or null stream to be detected next.</source>
+        <translation>Xing başlığı Mp3Fixer tarafından eklenmiş gibi görünüyor, bu program ilk çerçeveyi kullanılamaz hâle getirir ve ardından 16 baytlık bilinmeyen veya boş bir akışın bulunmasına sebep olur.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="210"/>
+        <source>Frame count mismatch between the Xing header and the audio stream.</source>
+        <translation>Xing başlığı ile ses akışı arasında çerçeve sayısı uyuşmazlığı.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="211"/>
+        <source>Two Xing headers found, but a file should have at most one of them.</source>
+        <translation>İki Xing başlığı tespit edildi, ancak her bir dosyanın sadece tek böyle başlığı bulunmalıdır.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="212"/>
+        <source>The Xing header should be located immediately before the MPEG audio stream.</source>
+        <translation>Xing başlığının MPEG ses akışından hemen önce konumlanması gerekir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="213"/>
+        <source>The Xing header should be compatible with the MPEG audio stream, meaning that their MPEG version, layer and frequency must be equal.</source>
+        <translation>Xing başlığı ile MPEG ses akışının uyumlu olması gerekir, yani MPEG sürümü, katmanı ve frekansının eşit olmaları gereklidir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="214"/>
+        <source>The MPEG audio stream uses VBR but a Xing header wasn&apos;t found. This will confuse some players, which won&apos;t be able to display the song duration or to seek.</source>
+        <translation>MPEG ses akışı VBR kullanıyor fakat hiçbir Xing başlığı bulunamadı. Bu, bazı oynatıcıları şaşırtabilir ve bunlar şarkı süresini görüntülemeyebilir veya arama yapamayabilirler.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="215"/>
+        <source>Xing header included in audio frame count. This is probably best ignored, as most players are fine with it and the fix erases potentially important information, like gapless playing information or the table of contents.</source>
+        <translation>Xing başlığı ses çerçeve sayısına dahil edilmiş. En iyisi muhtemelen bunu görmezden gelmektir, çünkü oynatıcıların çoğunluğu için sorun yaratmaz ve düzeltme, potansiyel olarak aralıksız çalma bilgileri veya içerik tablosu gibi önemli bilgileri silebilir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="218"/>
+        <source>Two VBRI headers found, but a file should have at most one of them.</source>
+        <translation>İki VBRI başlığı bulundu, ancak her bir dosyanın en çok bir başlık bulundurması gerekir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="219"/>
+        <source>VBRI headers aren&apos;t well supported by some players. They should be replaced by Xing headers.</source>
+        <translation>VBRI başlıkları bazı oynatıcılar tarafından iyi desteklenmezler. Bunların yerine Xing başlıkları konulması tercih edilmelidir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="220"/>
+        <source>VBRI header found alongside Xing header. The VBRI header should probably be removed.</source>
+        <translation>VBRI ve Xing başlıkları tespit edildi. Muhtemelen VBRI başlığını kaldırmak gereklidir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="223"/>
+        <source>Invalid ID3V2 frame. File too short.</source>
+        <translation>Geçersiz ID3V2 çerçevesi. Dosya çok kısa.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="224"/>
+        <source>Invalid frame name in ID3V2 tag.</source>
+        <translation>ID3V2 etiketindeki çerçeve ismi geçersiz.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="225"/>
+        <source>Flags in the first flag group that are supposed to always be 0 are set to 1. They will be ignored.</source>
+        <translation>Daima 0 değerinde olmaları beklenen ilk bayrak grubundaki bayraklar 1 değerine ayarlanmışlardır. Dikkate alınmayacaklar.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="226"/>
+        <source>Flags in the second flag group that are supposed to always be 0 are set to 1. They will be ignored.</source>
+        <translation>Daima 0 değerinde olmaları beklenen ikinci bayrak grubundaki bayraklar 1 değerine ayarlanmışlardır. Dikkate alınmayacaklar.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="227"/>
+        <source>Error decoding the value of a text frame while reading an Id3V2 Stream.</source>
+        <translation>ID3V2 akışı okunurken bir metin çerçevesinin kodlamasını açma esnasında hata.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="228"/>
+        <source>ID3V2 tag has text frames using Latin-1 encoding that contain characters with a code above 127. While this is valid, those frames may have their content set or displayed incorrectly by software that uses the local code page instead of Latin-1. Conversion to Unicode (UTF16) is recommended.</source>
+        <translation>ID3V2 etiketi, 127&apos;den yüksek kod içeren Latin 1 kodlaması ile metin çerçeveleri bulundurmaktadır. Her ne kadar bu geçerli olsa dahi, bu çerçevelerin içeriği Latin 1 yerine yerel kod sayfası kullanan yazılımlar tarafından yanlış ayarlanabilir veya görüntülenebilir. Unikod&apos;a (UTF16) dönüştürmek tavsiye edilir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="229"/>
+        <source>Empty genre frame (TCON) found.</source>
+        <translation>Boş tür çerçevesi (TCON) tespit edildi.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="230"/>
+        <source>Multiple frame instances found, but only the first one will be used.</source>
+        <translation>Birçok çerçeve örneklemesi tespit edildi, fakat sadece ilki kullanılacaktır.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="231"/>
+        <source>The padding in the ID3V2 tag is too large, wasting space. (Large padding improves the tag editor saving speed, if fast saving is enabled, so you may want to delay compacting the tag until after you&apos;re done with the tag editor.)</source>
+        <translation>ID3V2 etiketindeki dolgu çok büyük, bu da yer israfına yol açıyor. (Eğer hızlı kayıt etkinleştirildiyse büyük dolgular etiket düzenleyici kayıt sürelerini iyileştirir, dolayısıyla dolguyu sıkıştırmayı etiket düzenleyiciyle işiniz bitene kadar ertelemeyi tercih edebilirsiniz.)</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="232"/>
+        <source>Unsupported ID3V2 version.</source>
+        <translation>Desteklenmeyen ID3V2 sürümü.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="233"/>
+        <source>Unsupported ID3V2 tag. Unsupported flag.</source>
+        <translation>Desteklenmeyen ID3V2 etiketi. Desteklenmeyen bayrak.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="234"/>
+        <source>Unsupported value for Flags1 in ID3V2 frame. (This may also indicate that the file contains garbage where it was supposed to be zero.)</source>
+        <translation>ID3V2 çerçevesinde desteklenmeyen Flags1 değeri. (Bu, aynı zamanda sıfır olması gereken yerlerde yanlış veriler içerdiği anlamına gelebilir.)</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="235"/>
+        <source>Unsupported value for Flags2 in ID3V2 frame. (This may also indicate that the file contains garbage where it was supposed to be zero.)</source>
+        <translation>ID3V2 çerçevesinde desteklenmeyen Flags2 değeri. (Bu, aynı zamanda sıfır olması gereken yerlerde yanlış veriler içerdiği anlamına gelebilir.)</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="236"/>
+        <source>Multiple instances of the POPM frame found in ID3V2 tag. The current version discards all the instances except the first when processing this tag.</source>
+        <translation>ID3V2 etiketinde POPM çerçevesinin birçok örneklemesi tespit edildi. Güncel sürüm bu etiketi işlerken ilk örnekleme dışındakileri kaldıracaktır.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="237"/>
+        <source>ID3V2 tag contains no frames, which is invalid. This note will disappear once you add track information in the tag editor.</source>
+        <translation>ID3V2 etiketi hiçbir çerçeve içermemektedir, ki bu geçersizdir. Bu not, etiket düzenleyicide parça bilgisi eklediğinizde kalkacaktır.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="238"/>
+        <source>ID3V2 tag contains an empty text frame, which is invalid.</source>
+        <translation>ID3V2 etiketi boş bir metin çerçevesi içermektedir, ki bu geçersizdir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="241"/>
+        <source>ID3V2 tag doesn&apos;t have an APIC frame (which is used to store images).</source>
+        <translation>ID3V2 etiketi APIC çerçevesi içermemektedir (resim saklamak için kullanılır).</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="242"/>
+        <source>ID3V2 tag has an APIC frame (which is used to store images), but the image couldn&apos;t be loaded.</source>
+        <translation>ID3V2 etiketi bir APIC çerçevesi içermektedir (resim saklamak için kullanılır), fakat resim yüklenemedi.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="243"/>
+        <source>ID3V2 tag has at least one valid APIC frame (which is used to store images), but no frame has a type that is associated with an album cover.</source>
+        <translation>ID3V2 etiketi en az geçerli bir APIC çerçevesi bulundurmaktadır (resim saklamak için kullanılır), fakat hiçbir çerçevenin türü bir albüm kapağı ile ilişkili değildir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="244"/>
+        <source>Error loading image in APIC frame.</source>
+        <translation>APIC çerçevesindeki resmin yüklenmesinde hata.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="245"/>
+        <source>Error loading image in APIC frame. The frame is too short anyway to have space for an image.</source>
+        <translation>APIC çerçevesindeki resmin yüklenmesinde hata. Zaten bu çerçeve bir resim içermek için çok küçük.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="246"/>
+        <source>ID3V2 tag has multiple APIC frames with the same picture type.</source>
+        <translation>ID3V2 etiketi, aynı resim türü içeren birden fazla APIC çerçevesi bulunduruyor.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="247"/>
+        <source>ID3V2 tag has multiple APIC frames. While this is valid, players usually use only one of them to display an image, discarding the others.</source>
+        <translation>ID3V2 etiketi birden fazla APIC çerçevesine sahiptir. Bu geçerlidir ancak oynatıcılar genelde resim görüntülemek için sadece bir tanesini kullanıp diğerlerini dikkate almazlar.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="249"/>
+        <source>Unsupported text encoding for APIC frame in ID3V2 tag.</source>
+        <translation>ID3V2 etiketi içinde APIC çerçevesi için desteklenmeyen metin kodlaması.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="250"/>
+        <source>APIC frame uses a link to a file as a MIME Type, which is not supported.</source>
+        <translation>APIC çerçevesi, MIME Tipi olarak bir dosyaya bağlantı kullanmaktadır, ki bu desteklenmemektedir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="251"/>
+        <source>Picture description is ignored in the current version.</source>
+        <translation>Güncel sürümde resimlerin tanımlamaları dikkate alınmaz.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="252"/>
+        <source>Found image encoded as progressive JPEG. Some players might be incompatible with it.</source>
+        <translation>Aşamalı JPEG olarak kodlanmış bir resim tespit edildi. Bazı oynatıcılar onunla uyumsuz olabilir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="255"/>
+        <source>No ID3V2.3.0 tag found, although this is the most popular tag for storing song information.</source>
+        <translation>Hiçbir ID3V2.3.0 etiketi tespit edilemedi, halbuki bu, parçalara dair bilgi saklamak için en popüler etikettir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="256"/>
+        <source>Two ID3V2.3.0 tags found, but a file should have at most one of them.</source>
+        <translation>İki ID3V2.3.0 etiketi tespit edildi, ancak bir dosyanın bunlardan en çok bir etikete sahip olması gerekir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="257"/>
+        <source>Both ID3V2.3.0 and ID3V2.4.0 tags found, but there should be only one of them.</source>
+        <translation>Hem ID3V2.3.0 hem de ID3V2.4.0 etiketleri tespit edildi, ancak ikisinden sadece birisinin mevcut olması gerekir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="258"/>
+        <source>The ID3V2.3.0 tag should be the first tag in a file.</source>
+        <translation>ID3V2.3.0 etiketi dosyanın ilk etiketi olmalıdır.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="259"/>
+        <source>ID3V2.3.0 tag contains a text frame encoded as UTF-8, which is valid in ID3V2.4.0 but not in ID3V2.3.0.</source>
+        <translation>ID3V2.3.0 etiketi UTF-8 ile kodlanmış metin çerçevesi içermektedir, bu ID3V2.4.0 için geçerlidir fakat ID3V2.3.0 için geçersizdir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="260"/>
+        <source>Unsupported value of text frame while reading an Id3V2 Stream.</source>
+        <translation>ID3V2 akışı okunurken desteklenmeyen metin çerçevesi değeri.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="261"/>
+        <source>Invalid ID3V2.3.0 frame. Incorrect frame size or file too short.</source>
+        <translation>Geçersiz ID3V2.3.0 çerçevesi. Yanlış çerçeve boyutu veya çok küçük dosya boyutu.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="262"/>
+        <source>Invalid ID3V2.3.0 frame. Frame size is negative.</source>
+        <translation>Geçersiz ID3V2.3.0 çerçevesi. Çerçeve boyutu eksi bir sayı.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="263"/>
+        <source>Invalid ID3V2.3.0 frame. Maximum supported size is 64 MB.</source>
+        <translation>Geçersiz ID3V2.3.0 çerçevesi. Desteklenen azami boyut 64 MB&apos;dir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="264"/>
+        <source>ID3V2.3.0 frame is larger than usual, possibly wasting space.</source>
+        <translation>ID3V2.3.0 çerçevesi alışılagelmişten daha büyük, muhtemelen yer israf ediyor.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="267"/>
+        <source>Two ID3V2.4.0 tags found, but a file should have at most one of them.</source>
+        <translation>İki ID3V2.4.0 etiketi tespit edildi, ancak bir dosyanın böyle en çok bir etikete sahip olması beklenir..</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="268"/>
+        <source>Invalid ID3V2.4.0 frame. Incorrect frame size or file too short.</source>
+        <translation>Geçersiz ID3V2.4.0 çerçevesi. Yanlış çerçeve boyutu veya çok küçük dosya boyutu.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="269"/>
+        <source>Invalid ID3V2.4.0 frame. Frame size is supposed to be stored as a synchsafe integer, which uses only 7 bits in a byte, but the size uses all 8 bits, as in ID3V2.3.0. This will confuse some applications</source>
+        <translation>Geçersiz ID3V2.4.0 çerçevesi. Çerçeve boyutunun &quot;synchsafe&quot; tamsayı olarak saklanması beklenir, ki bu bir baytta sadece 7 bit kullanır, fakat boyut ID3V2.3.0 için olduğu gibi tüm 8 biti kullanmaktadır. Bu, bazı uygulamaları karıştırır</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="270"/>
+        <source>Deprecated TYER frame found in 2.4.0 tag alongside a TDRC frame.</source>
+        <translation>2.4.0 etiketinde TDRC çerçevesinin yanında kullanımdan kaldırılmış eski TYER çerçevesi bulundu.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="271"/>
+        <source>Deprecated TYER frame found in 2.4.0 tag. It&apos;s supposed to be replaced by a TDRC frame.</source>
+        <translation>2.4.0 etiketinde kullanımdan kaldırılmış eski TYER çerçevesi bulundu. Bunun yerine bir TDRC çerçevesi konması beklenir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="272"/>
+        <source>Deprecated TDAT frame found in 2.4.0 tag alongside a TDRC frame.</source>
+        <translation>2.4.0 etiketinde TDRC çerçevesinin yanında kullanımdan kaldırılmış eski TDAT çerçevesi bulundu.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="273"/>
+        <source>Deprecated TDAT frame found in 2.4.0 tag. It&apos;s supposed to be replaced by a TDRC frame.</source>
+        <translation>2.4.0 etiketinde kullanımdan kaldırılmış eski TDAT çerçevesi bulundu. Bunun yerine bir TDRC çerçevesi konması beklenir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="274"/>
+        <source>Invalid ID3V2.4.0 frame. Mismatched Data length indicator. Frame value is probably incorrect</source>
+        <translation>Geçersiz ID3V2.4.0 çerçevesi. Veri uzunluğu göstergesi uyuşmuyor. Çerçeve değeri muhtemelen yanlıştır</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="275"/>
+        <source>Invalid ID3V2.4.0 frame. Incorrect unsynchronization bit.</source>
+        <translation>Geçersiz ID3V2.4.0 çerçevesi. Yanlış eşleşmeme biti.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="276"/>
+        <source>Unsupported value of text frame while reading an Id3V2.4.0 stream. It may be using an unsupported text encoding.</source>
+        <translation>ID3V2.4.0 akışı okunurken desteklenmeyen metin çerçeve değeri. Desteklenmeyen bir metin kodlaması kullanıyor olabilir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="279"/>
+        <source>The only supported tag found that is capable of storing song information is ID3V1, which has pretty limited capabilities.</source>
+        <translation>Şarlı bilgisi saklama kabiliyetine sahip tespit edilen tek etiket ID3V1&apos;dir, ki kapasiteleri oldukça sınırlıdır.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="280"/>
+        <source>The ID3V1 tag should be located after the MPEG audio stream.</source>
+        <translation>ID3V1 etiketinin MPEG ses akışından sonra konumlanması gerekir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="281"/>
+        <source>Invalid ID3V1 tag. File too short.</source>
+        <translation>Geçersiz ID3V1 etiketi. Dosya çok kısa.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="282"/>
+        <source>Two ID3V1 tags found, but a file should have at most one of them.</source>
+        <translation>İki ID3V1 etiketi tespit edildi, ancak bir dosyanın böyle en çok bir etikete sahip olması beklenir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="284"/>
+        <source>ID3V1 tag contains fields padded with spaces alongside fields padded with zeroes. The standard only allows zeroes, but some tools use spaces. Even so, zero-padding and space-padding shouldn&apos;t be mixed.</source>
+        <translation>ID3V1 etiketi boşluklarla ve bunların yanında sıfırlarla dolgulanmış alanlar içermektedir. Standart, sadece sıfırlara izin verir, fakat bazı araçlar boşluklar kullanır. Her durumda sıfır dolgularıyla boşluk dolguları karıştırılmamalıdır.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="285"/>
+        <source>ID3V1 tag contains fields that are padded with spaces mixed with zeroes. The standard only allows zeroes, but some tools use spaces. Even so, one character should be used for padding for the whole tag.</source>
+        <translation>ID3V1 etiketi boşluklarla ve bunların yanında sıfırlarla dolgulanmış alanlar içermektedir. Standart, sadece sıfırlara izin verir, fakat bazı araçlar boşluklar kullanır. Her durumda bütün etiketi dolgulamak için tek bir karakter kullanılmalıdır.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="286"/>
+        <source>Invalid ID3V1 tag. Invalid characters in Name field.</source>
+        <translation>Geçersiz ID3V1 etiketi. İsim alanında geçersiz karakterler.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="287"/>
+        <source>Invalid ID3V1 tag. Invalid characters in Artist field.</source>
+        <translation>Geçersiz ID3V1 etiketi. Sanatçı alanında geçersiz karakterler.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="288"/>
+        <source>Invalid ID3V1 tag. Invalid characters in Album field.</source>
+        <translation>Geçersiz ID3V1 etiketi. Albüm alanında geçersiz karakterler.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="289"/>
+        <source>Invalid ID3V1 tag. Invalid characters in Year field.</source>
+        <translation>Geçersiz ID3V1 etiketi. Sene alanında geçersiz karakterler.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="290"/>
+        <source>Invalid ID3V1 tag. Invalid characters in Comment field.</source>
+        <translation>Geçersiz ID3V1 etiketi. Yorum alanında geçersiz karakterler.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="293"/>
+        <source>Broken stream found.</source>
+        <translation>Hasarlı akış tespit edildi.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="294"/>
+        <source>Broken stream found. Since other streams follow, it is possible that players and tools will have problems using the file. Removing the stream is recommended.</source>
+        <translation>Hasarlı akış tespit edildi. Başka akışlar takip ettiğinden dolayı oynatıcıların ve araçların bu dosyayı kullanmakta sorun yaşamaları muhtemeldir. Akışın kaldırılması tavsiye edilir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="297"/>
+        <source>Truncated MPEG stream found. The cause for this seems to be that the file was truncated.</source>
+        <translation>Kesik MPEG akışı tespit edildi. Bunun sebebi dosyanın kesik olması gibi görünüyor.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="298"/>
+        <source>Truncated MPEG stream found. Since other streams follow, it is possible that players and tools will have problems using the file. Removing the stream or padding it with 0 to reach its declared size is strongly recommended.</source>
+        <translation>Kesik MPEG akışı tespit edildi. Başka akışlar takip ettiğinden dolayı oynatıcıların ve araçların bu dosyayı kullanmakta sorun yaşamaları muhtemeldir. Akışın kaldırılması veya beyan edilen boyuta ulaşıncaya dek 0 ile dolgulanması hararetle tavsiye edilir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="301"/>
+        <source>Not enough remaining bytes to create an UnknownDataStream.</source>
+        <translation>Bilinmeyen veri akışı (UnknownDataStream) oluşturmak için kalan bayt sayısı yetersiz.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="302"/>
+        <source>Unknown stream found.</source>
+        <translation>Bilinmeyen akış tespit edildi.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="303"/>
+        <source>Unknown stream found. Since other streams follow, it is possible that players and tools will have problems using the file. Removing the stream is recommended.</source>
+        <translation>Bilinmeyen akış tespit edildi. Başka akışlar takip ettiğinden dolayı oynatıcıların ve araçların bu dosyayı kullanmakta sorun yaşamaları muhtemeldir. Akışın kaldırılması tavsiye edilir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="304"/>
+        <source>File contains null streams.</source>
+        <translation>Dosya boş akışlar içermektedir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="307"/>
+        <source>Invalid Lyrics stream tag. File too short.</source>
+        <translation>Geçersiz Şarkı Sözleri akış etiketi. Dosya çok kısa.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="308"/>
+        <source>Two Lyrics tags found, but only one is supported.</source>
+        <translation>İki Şarkı Sözleri etiketi tespit edildi, ancak sadece bir tanesi desteklenmektedir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="310"/>
+        <source>Invalid Lyrics stream tag. Unexpected characters found.</source>
+        <translation>Geçersiz Şarkı Sözleri akış etiketi. Beklenmeyen karakterler tespit edildi.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="311"/>
+        <source>Multiple fields with the same name were found in a Lyrics tag, but only one is supported.</source>
+        <translation>Şarkı Sözleri etiketinde aynı isimli birçok alan tespit edildi, ancak sadece bir tanesi desteklenmektedir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="313"/>
+        <source>Currently INF fields in Lyrics tags are not fully supported.</source>
+        <translation>Güncel olarak Şarkı Sözleri etiketlerinde INF alanları tam olarak desteklenmemektedir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="316"/>
+        <source>Invalid Ape Item. File too short.</source>
+        <translation>Geçersiz Ape unsuru. Dosya çok kısa.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="317"/>
+        <source>Ape Item seems too big. Although the size may be any 32-bit integer, 256 bytes should be enough in practice. If this note is determined to be incorrect, it will be removed in the future.</source>
+        <translation>Ape unsuru çok büyük gibi görünüyor. Her ne kadar boyut 32 bit üzerinde herhangi bir tamsayı olabilse dahi, pratikte 256 baytın yeterli olması beklenir. Bu not yanlış ise gelecekte kaldırılacaktır.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="318"/>
+        <source>Invalid Ape Item. Terminator not found for item name.</source>
+        <translation>Geçersiz Ape unsuru. Unsur ismi için sonlandırıcı bulunamadı.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="319"/>
+        <source>Invalid Ape tag. Header expected but footer found.</source>
+        <translation>Geçersiz Ape etiketi.Başlık bekleniyordu ancak altbilgi bulundu.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="320"/>
+        <source>Not an Ape tag. File too short.</source>
+        <translation>Ape etiketi değil. Dosya çok kısa.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="321"/>
+        <source>Invalid Ape tag. Footer expected but header found.</source>
+        <translation>Geçersiz Ape etiketi. Altbilgi bekleniyordu fakat başlık bulundu.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="322"/>
+        <source>Invalid Ape tag. Mismatch between header and footer.</source>
+        <translation>Geçersiz Ape etiketi. Başlık ile altbilgi arasında tutarsızlık var.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="323"/>
+        <source>Two Ape tags found, but only one is supported.</source>
+        <translation>İki Ape etiketi tespit edildi, ancak sadece bir tanesi desteklenir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="324"/>
+        <source>Ape item flags not supported.</source>
+        <translation>Ape unsurunun bayrakları desteklenmemektedir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="325"/>
+        <source>Unsupported Ape tag. Currently a missing header or footer are not supported.</source>
+        <translation>Desteklenmeyen Ape etiketi. Güncel olarak eksik bir başlık veya altbilgi desteklenmemektedir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="328"/>
+        <source>The file seems to have been changed in the (short) time that passed between parsing it and the initial search for pictures. If you think that&apos;s not the case, report a bug.</source>
+        <translation>Dosya, ayrıştırılması ve ilk resim araması arasında geçen (kısa) süre içinde değiştirilmiş gibi görünüyor. Eğer bunun böyle olmadığını düşünüyorsanız, bir hata raporunda bulunun.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="329"/>
+        <source>No supported tag found that is capable of storing song information.</source>
+        <translation>Şarkı bilgisi saklama kabiliyetine sahip hiçbir etiket tespit edilemedi.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="330"/>
+        <source>Too many TRACE notes added. The rest will be discarded.</source>
+        <translation>Çok fazla TRACE notu eklendi. Geri kalanlar dikkate alınmayacaktır.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="331"/>
+        <source>Too many notes added. The rest will be discarded.</source>
+        <translation>Çok fazla not eklendi. Geri kalanlar dikkate alınmayacaktır.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="332"/>
+        <source>Too many streams found. Aborting processing.</source>
+        <translation>Çok fazla akış tespit edildi. İşleyiş iptal ediliyor.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="333"/>
+        <source>Unsupported stream found. It may be supported in the future if there&apos;s a real need for it.</source>
+        <translation>Desteklenmeyen akış tespit edildi. Gelecekte, gerçekten ihtiyaç duyulması halinde desteklenebilir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="334"/>
+        <source>The file was saved using the &quot;fast&quot; option. While this improves the saving speed, it may leave the notes in an inconsistent state, so you should rescan the file.</source>
+        <translation>Dosya &quot;hızlı&quot; seçeneği kullanılarak kaydedilmiştir. Bu, her ne kadar kayıt süresini iyileştirse dahi, notları tutarsız bir durumda bırakabilir; dolayısıyla dosyayı tekrar taramanız tavsiye edilir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.h" line="335"/>
+        <source>An error occurred while reading the file, so it wasn&apos;t fully processed. This usually happens when reading from external drives or USB sticks, in which case a workaround might be to copy the files to an internal drive.</source>
+        <translation>Dosya okunurken bir hata meydana geldi, dolayısıyla tamamen işlenemedi. Bu genelde harici sürücülerden veya USB belleklerden okunurken meydana gelir, bu durumda geçici bir çözüm olarak dosyaları dahili bir sürücüye kopyalamak düşünülebilir.</translation>
+    </message>
+    <message>
+        <location filename="../Notes.cpp" line="386"/>
+        <source>ERROR</source>
+        <translation>HATA</translation>
+    </message>
+    <message>
+        <location filename="../Notes.cpp" line="387"/>
+        <source>WARNING</source>
+        <translation>İKAZ</translation>
+    </message>
+    <message>
+        <location filename="../Notes.cpp" line="388"/>
+        <source>SUPPORT</source>
+        <translation>DESTEK</translation>
+    </message>
+</context>
+<context>
+    <name>NoteFilterDlg</name>
+    <message>
+        <location filename="../NoteFilter.ui" line="14"/>
+        <source>Note filter</source>
+        <translation>Not filtresi</translation>
+    </message>
+    <message>
+        <location filename="../NoteFilter.ui" line="47"/>
+        <source>OK</source>
+        <translation>Tamam</translation>
+    </message>
+    <message>
+        <location filename="../NoteFilter.ui" line="54"/>
+        <source>Cancel</source>
+        <translation>İptal et</translation>
+    </message>
+</context>
+<context>
+    <name>NoteFilterDlgImpl</name>
+    <message>
+        <location filename="../NoteFilterDlgImpl.cpp" line="62"/>
+        <source>&lt;all notes&gt;</source>
+        <translation>&lt;tüm notlar&gt;</translation>
+    </message>
+    <message>
+        <location filename="../NoteFilterDlgImpl.cpp" line="89"/>
+        <source>Available notes</source>
+        <translation>Mevcut notlar</translation>
+    </message>
+    <message>
+        <location filename="../NoteFilterDlgImpl.cpp" line="90"/>
+        <source>Include notes</source>
+        <translation>Notları dahil et</translation>
+    </message>
+    <message>
+        <location filename="../NoteFilterDlgImpl.cpp" line="179"/>
+        <source>Add selected note(s)</source>
+        <translation>Seçili notları ekle</translation>
+    </message>
+    <message>
+        <location filename="../NoteFilterDlgImpl.cpp" line="180"/>
+        <source>Remove selected note(s)</source>
+        <translation>Seçili notları kaldır</translation>
+    </message>
+    <message>
+        <location filename="../NoteFilterDlgImpl.cpp" line="181"/>
+        <source>Add all notes</source>
+        <translation>Tüm notları ekle</translation>
+    </message>
+    <message>
+        <location filename="../NoteFilterDlgImpl.cpp" line="182"/>
+        <source>Remove all notes</source>
+        <translation>Tüm notları kaldır</translation>
+    </message>
+    <message>
+        <location filename="../NoteFilterDlgImpl.cpp" line="184"/>
+        <source>Restore lists to the configuration they had when the window was open</source>
+        <translation>Listeleri pencere açıkken sahip oldukları yapılandırmaya geri getir</translation>
+    </message>
+    <message>
+        <location filename="../NoteFilterDlgImpl.cpp" line="212"/>
+        <source>L</source>
+        <translation>L</translation>
+    </message>
+    <message>
+        <location filename="../NoteFilterDlgImpl.cpp" line="213"/>
+        <source>Note</source>
+        <translation>Not</translation>
+    </message>
+</context>
+<context>
+    <name>Notes</name>
+    <message>
+        <location filename="../Notes.cpp" line="42"/>
+        <source>&lt;Placeholder for a note that can no longer be found, most likely as a result of a software upgrade. You should rescan the file.&gt;</source>
+        <translation>&lt;Büyük ihtimalle yazılım güncellemesinin bir sonucu olarak bulunamayan bir not için yer tutucu. Dosyayı tekrar taramanız tavsiye edilir.&gt;</translation>
+    </message>
+    <message>
+        <source>ERROR</source>
+        <translation type="vanished">HATA</translation>
+    </message>
+    <message>
+        <source>WARNING</source>
+        <translation type="vanished">İKAZ</translation>
+    </message>
+    <message>
+        <source>SUPPORT</source>
+        <translation type="vanished">DESTEK</translation>
+    </message>
+    <message>
+        <source>Two MPEG audio streams found, but a file should have exactly one.</source>
+        <translation type="vanished">İki MPEG akışı tespit edildi, ancak bir dosya tam olarak tek bir akışa sahip olabilir.</translation>
+    </message>
+    <message>
+        <source>Low quality MPEG audio stream. (What is considered &quot;low quality&quot; can be changed in the configuration dialog, under &quot;Quality thresholds&quot;.)</source>
+        <translation type="vanished">Düşük kaliteli MPEG akışı (&quot;düşük kalite&quot; olarak neyin kabul edileceği yapılandırmadaki &quot;Kalite eşikleri&quot; sekmesinde değiştirilebilir.)</translation>
+    </message>
+    <message>
+        <source>No MPEG audio stream found.</source>
+        <translation type="vanished">Hiçbir MPEG ses akışı bulunamadı.</translation>
+    </message>
+    <message>
+        <source>VBR with audio streams other than MPEG1 Layer III might work incorrectly.</source>
+        <translation type="vanished">MPEG1 Layer III dışındaki VBR ses akışları yanlış çalışabilir.</translation>
+    </message>
+    <message>
+        <source>Incomplete MPEG frame at the end of an MPEG stream.</source>
+        <translation type="vanished">MPEG akışının sonunda tamamlanmamış bir MPEG çerçevesi.</translation>
+    </message>
+    <message>
+        <source>Valid frame with a different version found after an MPEG stream.</source>
+        <translation type="vanished">Bir MPEG akışından sonra başka sürümlü, geçerli bir çerçeve bulundu.</translation>
+    </message>
+    <message>
+        <source>Valid frame with a different layer found after an MPEG stream.</source>
+        <translation type="vanished">Bir MPEG akışından sonra geçerli ama değişik bir layer (katmanlı) çerçeve bulundu.</translation>
+    </message>
+    <message>
+        <source>Valid frame with a different channel mode found after an MPEG stream.</source>
+        <translation type="vanished">Bir MPEG akışından sonra geçerli ama farklı bir kanal kipinde çerçeve bulundu.</translation>
+    </message>
+    <message>
+        <source>Valid frame with a different frequency found after an MPEG stream.</source>
+        <translation type="vanished">Bir MPEG akışından sonra geçerli ama farklı bir frekansı olan bir çerçeve bulundu.</translation>
+    </message>
+    <message>
+        <source>Valid frame with a different CRC policy found after an MPEG stream.</source>
+        <translation type="vanished">Bir MPEG akışından sonra geçerli ama farklı bir CRC politikası olan bir çerçeve bulundu.</translation>
+    </message>
+    <message>
+        <source>Invalid MPEG stream. Stream has fewer than 10 frames.</source>
+        <translation type="vanished">Geçersiz MPEG akışı. Akış, 10&apos;dan az çerçeve barındırmaktadır.</translation>
+    </message>
+    <message>
+        <source>Invalid MPEG stream. First frame has different bitrate than the rest.</source>
+        <translation type="vanished">Geçersiz MPEG akışı. İlk çerçevenin bir hızı diğerlerinden farklıdır.</translation>
+    </message>
+    <message>
+        <source>No normalization undo information found. The song is probably not normalized by MP3Gain or a similar program. As a result, it may sound too loud or too quiet when compared to songs from other albums.</source>
+        <translation type="vanished">Normalleştirmeyi geri almak için hiçbir veri bulunamadı. Şarkı, muhtemelen MP3Gain veya benzer bir program tarafından normalleştirilmemiştir. Bunun sonucu olarak, diğer albümlerin şarkılarıyla karşılaştırıldığında sesi çok yüksek veya çok düşük olabilir.</translation>
+    </message>
+    <message>
+        <source>Found audio stream in an encoding other than &quot;MPEG-1 Layer 3&quot; or &quot;MPEG-2 Layer 3.&quot; While MP3 Diags understands such streams, very few tests were run on files containing them (because they are not supposed to be found inside files with the &quot;.mp3&quot; extension), so there is a bigger chance of something going wrong while processing them.</source>
+        <translation type="vanished">&quot;MPEG 1 Layer 3&quot; veya &quot;MPEG 2 Layer 3&quot; kodlamasından farklı kodlamalı bir ses akışı bulundu. MP3 Diags böyle akışları anlasa dahi, bunları içeren dosyalar ile çok az deneme yapılmıştır (çünkü &quot;.mp3&quot; uzantısını kullanan dosyalar içinde bulunmaları beklenmez), yani onları işlerken bir şeylerin yolunda gitmemesi ihtimali daha yüksektir.</translation>
+    </message>
+    <message>
+        <source>Two Lame headers found, but a file should have at most one of them.</source>
+        <translation type="vanished">İki Lame başlığı bulundu, ancak bir dosyanın bunlardan sadece bir başlık bulundurması beklenir.</translation>
+    </message>
+    <message>
+        <source>Xing header seems added by Mp3Fixer, which makes the first frame unusable and causes a 16-byte unknown or null stream to be detected next.</source>
+        <translation type="vanished">Xing başlığı Mp3Fixer tarafından eklenmiş gibi görünüyor, bu program ilk çerçeveyi kullanılamaz hâle getirir ve ardından 16 baytlık bilinmeyen veya boş bir akışın bulunmasına sebep olur.</translation>
+    </message>
+    <message>
+        <source>Frame count mismatch between the Xing header and the audio stream.</source>
+        <translation type="vanished">Xing başlığı ile ses akışı arasında çerçeve sayısı uyuşmazlığı.</translation>
+    </message>
+    <message>
+        <source>Two Xing headers found, but a file should have at most one of them.</source>
+        <translation type="vanished">İki Xing başlığı tespit edildi, ancak her bir dosyanın sadece tek böyle başlığı bulunmalıdır.</translation>
+    </message>
+    <message>
+        <source>The Xing header should be located immediately before the MPEG audio stream.</source>
+        <translation type="vanished">Xing başlığının ses akışından hemen sonra konumlanması gerekir.</translation>
+    </message>
+    <message>
+        <source>The Xing header should be compatible with the MPEG audio stream, meaning that their MPEG version, layer and frequency must be equal.</source>
+        <translation type="vanished">Xing başlığı ile MPEG ses akışının uyumlu olması gerekir, yani MPEG sürümü, katmanı ve frekansının eşit olmaları gereklidir.</translation>
+    </message>
+    <message>
+        <source>The MPEG audio stream uses VBR but a Xing header wasn&apos;t found. This will confuse some players, which won&apos;t be able to display the song duration or to seek.</source>
+        <translation type="vanished">MPEG ses akışı VBR kullanıyor fakat hiçbir Xing başlığı bulunamadı. Bu, bazı oynatıcıları şaşırtabilir ve bunlar şarkı süresini görüntülemeyebilir veya arama yapamayabilirler.</translation>
+    </message>
+    <message>
+        <source>Xing header included in audio frame count. This is probably best ignored, as most players are fine with it and the fix erases potentially important information, like gapless playing information or the table of contents.</source>
+        <translation type="vanished">Xing başlığı ses çerçeve sayısına dahil edilmiş. En iyisi muhtemelen bunu görmezden gelmektir, çünkü oynatıcıların çoğunluğu için sorun yaratmaz ve düzeltme potansiyel olarak arasız çalma bilgileri veya içerik tablosu gibi önemli bilgileri silebilir.</translation>
+    </message>
+    <message>
+        <source>Two VBRI headers found, but a file should have at most one of them.</source>
+        <translation type="vanished">İki VBRI başlığı bulundu, ancak her bir dosyanın en çok bir başlık bulundurması gerekir.</translation>
+    </message>
+    <message>
+        <source>VBRI headers aren&apos;t well supported by some players. They should be replaced by Xing headers.</source>
+        <translation type="vanished">VBRI başlıkları bazı oynatıcılar tarafından iyi desteklenmezler. Bunların yerine Xing başlıkları konulması tercih edilmelidir.</translation>
+    </message>
+    <message>
+        <source>VBRI header found alongside Xing header. The VBRI header should probably be removed.</source>
+        <translation type="vanished">VBRI ve Xing başlıkları tespit edildi. Muhtemelen VBRI başlığını kaldırmak gereklidir.</translation>
+    </message>
+    <message>
+        <source>Invalid ID3V2 frame. File too short.</source>
+        <translation type="vanished">Geçersiz ID3V2 çerçevesi. Dosya çok kısa.</translation>
+    </message>
+    <message>
+        <source>Invalid frame name in ID3V2 tag.</source>
+        <translation type="vanished">ID3V2 etiketindeki çerçeve ismi geçersiz.</translation>
+    </message>
+    <message>
+        <source>Flags in the first flag group that are supposed to always be 0 are set to 1. They will be ignored.</source>
+        <translation type="vanished">Daima 0 değerinde olmaları beklenen ilk bayrak grubundaki bayraklar 1 değerine ayarlanmışlardır. Dikkate alınmayacaklar.</translation>
+    </message>
+    <message>
+        <source>Flags in the second flag group that are supposed to always be 0 are set to 1. They will be ignored.</source>
+        <translation type="vanished">Daima 0 değerinde olmaları beklenen ikinci bayrak grubundaki bayraklar 1 değerine ayarlanmışlardır. Dikkate alınmayacaklar.</translation>
+    </message>
+    <message>
+        <source>Error decoding the value of a text frame while reading an Id3V2 Stream.</source>
+        <translation type="vanished">ID3V2 akışı okunurken bir metin çerçevesinin kodlamasını açma esnasında hata.</translation>
+    </message>
+    <message>
+        <source>ID3V2 tag has text frames using Latin-1 encoding that contain characters with a code above 127. While this is valid, those frames may have their content set or displayed incorrectly by software that uses the local code page instead of Latin-1. Conversion to Unicode (UTF16) is recommended.</source>
+        <translation type="vanished">ID3V2 etiketi, 127&apos;den yüksek kod içeren Latin 1 kodlaması ile metin çerçeveleri bulundurmaktadır. Her ne kadar bu geçerli olsa dahi, bu çerçevelerin içeriği Latin 1 yerine yerel kod sayfası kullanan yazılımlar tarafından yanlış ayarlanabilir veya görüntülenebilir. Unikod&apos;a (UTF16) dönüştürme tavsiye edilir.</translation>
+    </message>
+    <message>
+        <source>Empty genre frame (TCON) found.</source>
+        <translation type="vanished">Boş tür çerçevesi (TCON) tespit edildi.</translation>
+    </message>
+    <message>
+        <source>Multiple frame instances found, but only the first one will be used.</source>
+        <translation type="vanished">Birçok çerçeve örneklemesi tespit edildi, fakat sadece ilki kullanılacaktır.</translation>
+    </message>
+    <message>
+        <source>The padding in the ID3V2 tag is too large, wasting space. (Large padding improves the tag editor saving speed, if fast saving is enabled, so you may want to delay compacting the tag until after you&apos;re done with the tag editor.)</source>
+        <translation type="vanished">ID3V2 etiketindeki dolgu çok büyük, bu da yer israfına yol açıyor. (Eğer hızlı kayıt etkinleştirildiyse büyük dolgular etiket düzenleyici kayıt sürelerini iyileştirir, dolayısıyla dolguyu sıkıştırmayı etiket düzenleyiciyle işiniz bitene kadar ertelemeyi tercih edebilirsiniz.)</translation>
+    </message>
+    <message>
+        <source>Unsupported ID3V2 version.</source>
+        <translation type="vanished">Desteklenmeyen ID3V2 sürümü.</translation>
+    </message>
+    <message>
+        <source>Unsupported ID3V2 tag. Unsupported flag.</source>
+        <translation type="vanished">Desteklenmeyen ID3V2 etiketi. Desteklenmeyen bayrak.</translation>
+    </message>
+    <message>
+        <source>Unsupported value for Flags1 in ID3V2 frame. (This may also indicate that the file contains garbage where it was supposed to be zero.)</source>
+        <translation type="vanished">ID3V2 çerçevesinde desteklenmeyen Flags1 değeri. (Bu, aynı zamanda sıfır olması gereken yerlerde yanlış veriler içerdiği anlamına gelebilir.)</translation>
+    </message>
+    <message>
+        <source>Unsupported value for Flags2 in ID3V2 frame. (This may also indicate that the file contains garbage where it was supposed to be zero.)</source>
+        <translation type="vanished">ID3V2 çerçevesinde desteklenmeyen Flags2 değeri. (Bu, aynı zamanda sıfır olması gereken yerlerde yanlış veriler içerdiği anlamına gelebilir.)</translation>
+    </message>
+    <message>
+        <source>Multiple instances of the POPM frame found in ID3V2 tag. The current version discards all the instances except the first when processing this tag.</source>
+        <translation type="vanished">ID3V2 etiketinde POPM çerçevesinin birçok örneklemesi tespit edildi. Güncel sürüm bu etiketi işlerken ilk örnekleme dışındakileri kaldıracaktır.</translation>
+    </message>
+    <message>
+        <source>ID3V2 tag contains no frames, which is invalid. This note will disappear once you add track information in the tag editor.</source>
+        <translation type="vanished">ID3V2 etiketi hiçbir çerçeve içermemektedir, ki bu geçersizdir. Bu not, etiket düzenleyicide parça bilgisi eklediğinizde kalkacaktır.</translation>
+    </message>
+    <message>
+        <source>ID3V2 tag contains an empty text frame, which is invalid.</source>
+        <translation type="vanished">ID3V2 etiketi boş bir metin çerçevesi içermektedir, ki bu geçersizdir.</translation>
+    </message>
+    <message>
+        <source>ID3V2 tag doesn&apos;t have an APIC frame (which is used to store images).</source>
+        <translation type="vanished">ID3V2 etiketi APIC çerçevesi içermemektedir (resim saklamak için kullanılır).</translation>
+    </message>
+    <message>
+        <source>ID3V2 tag has an APIC frame (which is used to store images), but the image couldn&apos;t be loaded.</source>
+        <translation type="vanished">ID3V2 etiketi bir APIC çerçevesi içermektedir (resim saklamak için kullanılır), fakat resim yüklenemedi.</translation>
+    </message>
+    <message>
+        <source>ID3V2 tag has at least one valid APIC frame (which is used to store images), but no frame has a type that is associated with an album cover.</source>
+        <translation type="vanished">ID3V2 etiketi en az geçerli bir APIC çerçevesi bulundurmaktadır (resim saklamak için kullanılır), fakat hiçbir çerçevenin türü bir albüm kapağı ile ilişkili değildir.</translation>
+    </message>
+    <message>
+        <source>Error loading image in APIC frame.</source>
+        <translation type="vanished">APIC çerçevesindeki resmin yüklenmesinde hata.</translation>
+    </message>
+    <message>
+        <source>Error loading image in APIC frame. The frame is too short anyway to have space for an image.</source>
+        <translation type="vanished">APIC çerçevesindeki resmin yüklenmesinde hata. Zaten bu çerçeve bir resim içermek için çok küçük.</translation>
+    </message>
+    <message>
+        <source>ID3V2 tag has multiple APIC frames with the same picture type.</source>
+        <translation type="vanished">ID3V2 etiketi, aynı resim türü içeren birden fazla APIC çerçevesi bulunduruyor.</translation>
+    </message>
+    <message>
+        <source>ID3V2 tag has multiple APIC frames. While this is valid, players usually use only one of them to display an image, discarding the others.</source>
+        <translation type="vanished">ID3V2 etiketi birden fazla APIC çerçevesine sahiptir. Bu geçerlidir ancak oynatıcılar genelde resim görüntülemek için sadece bir tanesini kullanıp diğerlerini dikkate almazlar.</translation>
+    </message>
+    <message>
+        <source>Unsupported text encoding for APIC frame in ID3V2 tag.</source>
+        <translation type="vanished">ID3V2 etiketi içinde APIC çerçevesi için desteklenmeyen metin kodlaması.</translation>
+    </message>
+    <message>
+        <source>APIC frame uses a link to a file as a MIME Type, which is not supported.</source>
+        <translation type="vanished">APIC çerçevesi, MIME Tipi olarak bir dosyaya bağlantı kullanmaktadır, ki bu desteklenmemektedir.</translation>
+    </message>
+    <message>
+        <source>Picture description is ignored in the current version.</source>
+        <translation type="vanished">Güncel sürümde resimlerin tanımlamaları dikkate alınmaz.</translation>
+    </message>
+    <message>
+        <source>No ID3V2.3.0 tag found, although this is the most popular tag for storing song information.</source>
+        <translation type="vanished">Hiçbir ID3V2.3.0 etiketi tespit edilemedi, halbuki bu, parçalara dair bilgi saklamak için en popüler etikettir.</translation>
+    </message>
+    <message>
+        <source>Two ID3V2.3.0 tags found, but a file should have at most one of them.</source>
+        <translation type="vanished">İki ID3V2.3.0 etiketi tespit edildi, ancak bir dosyanın bunlardan en çok bir etikete sahip olması gerekir.</translation>
+    </message>
+    <message>
+        <source>Both ID3V2.3.0 and ID3V2.4.0 tags found, but there should be only one of them.</source>
+        <translation type="vanished">Hem ID3V2.3.0 hem de ID3V2.4.0 etiketleri tespit edildi, ancak ikisinden sadece birisinin mevcut olması gerekir.</translation>
+    </message>
+    <message>
+        <source>The ID3V2.3.0 tag should be the first tag in a file.</source>
+        <translation type="vanished">ID3V2.3.0 etiketi dosyanın ilk etiketi olmalıdır.</translation>
+    </message>
+    <message>
+        <source>ID3V2.3.0 tag contains a text frame encoded as UTF-8, which is valid in ID3V2.4.0 but not in ID3V2.3.0.</source>
+        <translation type="vanished">ID3V2.3.0 etiketi UTF-8 ile kodlanmış metin çerçevesi içermektedir, bu ID3V2.4.0 için geçerlidir fakat ID3V2.3.0 için geçersizdir.</translation>
+    </message>
+    <message>
+        <source>Unsupported value of text frame while reading an Id3V2 Stream.</source>
+        <translation type="vanished">ID3V2 akışı okunurken desteklenmeyen metin çerçevesi değeri.</translation>
+    </message>
+    <message>
+        <source>Invalid ID3V2.3.0 frame. Incorrect frame size or file too short.</source>
+        <translation type="vanished">Geçersiz ID3V2.3.0 çerçevesi. Yanlış çerçeve boyutu veya çok küçük dosya boyutu.</translation>
+    </message>
+    <message>
+        <source>Two ID3V2.4.0 tags found, but a file should have at most one of them.</source>
+        <translation type="vanished">İki ID3V2.4.0 etiketi tespit edildi, ancak bir dosyanın böyle en çok bir etikete sahip olması beklenir..</translation>
+    </message>
+    <message>
+        <source>Invalid ID3V2.4.0 frame. Incorrect frame size or file too short.</source>
+        <translation type="vanished">Geçersiz ID3V2.4.0 çerçevesi. Yanlış çerçeve boyutu veya çok küçük dosya boyutu.</translation>
+    </message>
+    <message>
+        <source>Invalid ID3V2.4.0 frame. Frame size is supposed to be stored as a synchsafe integer, which uses only 7 bits in a byte, but the size uses all 8 bits, as in ID3V2.3.0. This will confuse some applications</source>
+        <translation type="vanished">Geçersiz ID3V2.4.0 çerçevesi. Çerçeve boyutunun &quot;synchsafe&quot; tamsayı olarak saklanması beklenir, ki bu bir baytta sadece 7 bit kullanır, fakat boyut ID3V2.3.0 için olduğu gibi tüm 8 biti kullanmaktadır. Bu, bazı uygulamaları karıştırır</translation>
+    </message>
+    <message>
+        <source>Deprecated TYER frame found in 2.4.0 tag alongside a TDRC frame.</source>
+        <translation type="vanished">2.4.0 etiketinde TDRC çerçevesinin yanında kullanımdan kaldırılmış eski TYER çerçevesi bulundu.</translation>
+    </message>
+    <message>
+        <source>Deprecated TYER frame found in 2.4.0 tag. It&apos;s supposed to be replaced by a TDRC frame.</source>
+        <translation type="vanished">2.4.0 etiketinde kullanımdan kaldırılmış eski TYER çerçevesi bulundu. Bunun yerine bir TDRC çerçevesi konması beklenir.</translation>
+    </message>
+    <message>
+        <source>Deprecated TDAT frame found in 2.4.0 tag alongside a TDRC frame.</source>
+        <translation type="vanished">2.4.0 etiketinde TDRC çerçevesinin yanında kullanımdan kaldırılmış eski TDAT çerçevesi bulundu.</translation>
+    </message>
+    <message>
+        <source>Deprecated TDAT frame found in 2.4.0 tag. It&apos;s supposed to be replaced by a TDRC frame.</source>
+        <translation type="vanished">2.4.0 etiketinde kullanımdan kaldırılmış eski TDAT çerçevesi bulundu. Bunun yerine bir TDRC çerçevesi konması beklenir.</translation>
+    </message>
+    <message>
+        <source>Invalid ID3V2.4.0 frame. Mismatched Data length indicator. Frame value is probably incorrect</source>
+        <translation type="vanished">Geçersiz ID3V2.4.0 çerçevesi. Veri uzunluğu göstergesi uyuşmuyor. Çerçeve değeri muhtemelen yanlıştır</translation>
+    </message>
+    <message>
+        <source>Invalid ID3V2.4.0 frame. Incorrect unsynchronization bit.</source>
+        <translation type="vanished">Geçersiz ID3V2.4.0 çerçevesi. Yanlış eşleşme biti.</translation>
+    </message>
+    <message>
+        <source>Unsupported value of text frame while reading an Id3V2.4.0 stream. It may be using an unsupported text encoding.</source>
+        <translation type="vanished">ID3V2.4.0 akışı okunurken desteklenmeyen metin çerçeve değeri. Desteklenmeyen bir metin kodlaması kullanıyor olabilir.</translation>
+    </message>
+    <message>
+        <source>The only supported tag found that is capable of storing song information is ID3V1, which has pretty limited capabilities.</source>
+        <translation type="vanished">Şarlı bilgisi saklama kabiliyetine sahip tespit edilen tek etiket ID3V1&apos;dir, ki kapasiteleri oldukça sınırlıdır.</translation>
+    </message>
+    <message>
+        <source>The ID3V1 tag should be located after the MPEG audio stream.</source>
+        <translation type="vanished">ID3V1 etiketinin MPEG ses akışından hemen sonra konumlanması gerekir.</translation>
+    </message>
+    <message>
+        <source>Invalid ID3V1 tag. File too short.</source>
+        <translation type="vanished">Geçersiz ID3V1 etiketi. Dosya çok kısa.</translation>
+    </message>
+    <message>
+        <source>Two ID3V1 tags found, but a file should have at most one of them.</source>
+        <translation type="vanished">İki ID3V1 etiketi tespit edildi, ancak bir dosyanın böyle en çok bir etikete sahip olması beklenir.</translation>
+    </message>
+    <message>
+        <source>ID3V1 tag contains fields padded with spaces alongside fields padded with zeroes. The standard only allows zeroes, but some tools use spaces. Even so, zero-padding and space-padding shouldn&apos;t be mixed.</source>
+        <translation type="vanished">ID3V1 etiketi boşluklarla ve bunların yanında sıfırlarla dolgulanmış alanlar içermektedir. Standart, sadece sıfırlara izin verir, fakat bazı araçlar boşluklar kullanır. Her durumda sıfır dolgularıyla boşluk dolguları karıştırılmamalıdır.</translation>
+    </message>
+    <message>
+        <source>ID3V1 tag contains fields that are padded with spaces mixed with zeroes. The standard only allows zeroes, but some tools use spaces. Even so, one character should be used for padding for the whole tag.</source>
+        <translation type="vanished">ID3V1 etiketi boşluklarla ve bunların yanında sıfırlarla dolgulanmış alanlar içermektedir. Standart, sadece sıfırlara izin verir, fakat bazı araçlar boşluklar kullanır. Her durumda bütün etiketi dolgulamak için tek bir karakter kullanılmalıdır.</translation>
+    </message>
+    <message>
+        <source>Invalid ID3V1 tag. Invalid characters in Name field.</source>
+        <translation type="vanished">Geçersiz ID3V1 etiketi. İsim alanında geçersiz karakterler.</translation>
+    </message>
+    <message>
+        <source>Invalid ID3V1 tag. Invalid characters in Artist field.</source>
+        <translation type="vanished">Geçersiz ID3V1 etiketi. Sanatçı alanında geçersiz karakterler.</translation>
+    </message>
+    <message>
+        <source>Invalid ID3V1 tag. Invalid characters in Album field.</source>
+        <translation type="vanished">Geçersiz ID3V1 etiketi. Albüm alanında geçersiz karakterler.</translation>
+    </message>
+    <message>
+        <source>Invalid ID3V1 tag. Invalid characters in Year field.</source>
+        <translation type="vanished">Geçersiz ID3V1 etiketi. Sene alanında geçersiz karakterler.</translation>
+    </message>
+    <message>
+        <source>Invalid ID3V1 tag. Invalid characters in Comment field.</source>
+        <translation type="vanished">Geçersiz ID3V1 etiketi. Yorum alanında geçersiz karakterler.</translation>
+    </message>
+    <message>
+        <source>Broken stream found.</source>
+        <translation type="vanished">Hasarlı akış tespit edildi.</translation>
+    </message>
+    <message>
+        <source>Broken stream found. Since other streams follow, it is possible that players and tools will have problems using the file. Removing the stream is recommended.</source>
+        <translation type="vanished">Hasarlı akış tespit edildi. Başka akışlar takip ettiğinden dolayı oynatıcıların ve araçların bu dosyayı kullanmakta sorun yaşamaları muhtemeldir. Akışın kaldırılması tavsiye edilir.</translation>
+    </message>
+    <message>
+        <source>Truncated MPEG stream found. The cause for this seems to be that the file was truncated.</source>
+        <translation type="vanished">Kesik MPEG akışı tespit edildi. Bunun sebebi dosyanın kesik olması gibi görünüyor.</translation>
+    </message>
+    <message>
+        <source>Truncated MPEG stream found. Since other streams follow, it is possible that players and tools will have problems using the file. Removing the stream or padding it with 0 to reach its declared size is strongly recommended.</source>
+        <translation type="vanished">Kesik MPEG akışı tespit edildi. Başka akışlar takip ettiğinden dolayı oynatıcıların ve araçların bu dosyayı kullanmakta sorun yaşamaları muhtemeldir. Akışın kaldırılması veya beyan edilen boyuta ulaşıncaya dek 0 ile dolgulanması hararetle tavsiye edilir.</translation>
+    </message>
+    <message>
+        <source>Not enough remaining bytes to create an UnknownDataStream.</source>
+        <translation type="vanished">Bilinmeyen veri akışı (UnknownDataStream) oluşturmak için kalan bayt sayısı yetersiz.</translation>
+    </message>
+    <message>
+        <source>Unknown stream found.</source>
+        <translation type="vanished">Bilinmeyen akış tespit edildi.</translation>
+    </message>
+    <message>
+        <source>Unknown stream found. Since other streams follow, it is possible that players and tools will have problems using the file. Removing the stream is recommended.</source>
+        <translation type="vanished">Bilinmeyen akış tespit edildi. Başka akışlar takip ettiğinden dolayı oynatıcıların ve araçların bu dosyayı kullanmakta sorun yaşamaları muhtemeldir. Akışın kaldırılması tavsiye edilir.</translation>
+    </message>
+    <message>
+        <source>File contains null streams.</source>
+        <translation type="vanished">Dosya boş akışlar içermektedir.</translation>
+    </message>
+    <message>
+        <source>Invalid Lyrics stream tag. File too short.</source>
+        <translation type="vanished">Geçersiz Şarkı Sözleri akış etiketi. Dosya çok kısa.</translation>
+    </message>
+    <message>
+        <source>Two Lyrics tags found, but only one is supported.</source>
+        <translation type="vanished">İki Şarkı Sözleri etiketi tespit edildi, ancak sadece bir tanesi desteklenmektedir.</translation>
+    </message>
+    <message>
+        <source>Invalid Lyrics stream tag. Unexpected characters found.</source>
+        <translation type="vanished">Geçersiz Şarkı Sözleri akış etiketi. Beklenmeyen karakterler tespit edildi.</translation>
+    </message>
+    <message>
+        <source>Multiple fields with the same name were found in a Lyrics tag, but only one is supported.</source>
+        <translation type="vanished">Şarkı Sözleri etiketinde aynı isimli birçok alan tespit edildi, ancak sadece bir tanesi desteklenmektedir.</translation>
+    </message>
+    <message>
+        <source>Currently INF fields in Lyrics tags are not fully supported.</source>
+        <translation type="vanished">Güncel olarak Şarkı Sözleri etiketlerinde INF alanları tam olarak desteklenmemektedir.</translation>
+    </message>
+    <message>
+        <source>Invalid Ape Item. File too short.</source>
+        <translation type="vanished">Geçersiz Ape unsuru. Dosya çok kısa.</translation>
+    </message>
+    <message>
+        <source>Ape Item seems too big. Although the size may be any 32-bit integer, 256 bytes should be enough in practice. If this note is determined to be incorrect, it will be removed in the future.</source>
+        <translation type="vanished">Ape unsuru çok büyük gibi görünüyor. Her ne kadar boyut 32 bit üzerinde herhangi bir tamsayı olabilse dahi, pratikte 256 baytın yeterli olması beklenir. Bu not yanlış ise gelecekte kaldırılacaktır.</translation>
+    </message>
+    <message>
+        <source>Invalid Ape Item. Terminator not found for item name.</source>
+        <translation type="vanished">Geçersiz Ape unsuru. Unsur ismi için sonlandırıcı bulunamadı.</translation>
+    </message>
+    <message>
+        <source>Invalid Ape tag. Header expected but footer found.</source>
+        <translation type="vanished">Geçersiz Ape etiketi.Başlık bekleniyordu ancak altbilgi bulundu.</translation>
+    </message>
+    <message>
+        <source>Not an Ape tag. File too short.</source>
+        <translation type="vanished">Ape etiketi değil. Dosya çok kısa.</translation>
+    </message>
+    <message>
+        <source>Invalid Ape tag. Footer expected but header found.</source>
+        <translation type="vanished">Geçersiz Ape etiketi. Altbilgi bekleniyordu fakat başlık bulundu.</translation>
+    </message>
+    <message>
+        <source>Invalid Ape tag. Mismatch between header and footer.</source>
+        <translation type="vanished">Geçersiz Ape etiketi. Başlık ile altbilgi arasında tutarsızlık var.</translation>
+    </message>
+    <message>
+        <source>Two Ape tags found, but only one is supported.</source>
+        <translation type="vanished">İki Ape etiketi tespit edildi, ancak sadece bir tanesi desteklenir.</translation>
+    </message>
+    <message>
+        <source>Ape item flags not supported.</source>
+        <translation type="vanished">Ape unsurunun bayrakları desteklenmemektedir.</translation>
+    </message>
+    <message>
+        <source>Unsupported Ape tag. Currently a missing header or footer are not supported.</source>
+        <translation type="vanished">Desteklenmeyen Ape etiketi. Güncel olarak eksik bir başlık veya altbilgi desteklenmemektedir.</translation>
+    </message>
+    <message>
+        <source>The file seems to have been changed in the (short) time that passed between parsing it and the initial search for pictures. If you think that&apos;s not the case, report a bug.</source>
+        <translation type="vanished">Dosya, ayrıştırılması ve ilk resim araması arasında geçen (kısa) süre içinde değiştirilmiş gibi görünüyor. Eğer bunun böyle olmadığını düşünüyorsanız, bir hata raporunda bulunun.</translation>
+    </message>
+    <message>
+        <source>No supported tag found that is capable of storing song information.</source>
+        <translation type="vanished">Şarkı bilgisi saklama kabiliyetine sahip hiçbir etiket tespit edilemedi.</translation>
+    </message>
+    <message>
+        <source>Too many TRACE notes added. The rest will be discarded.</source>
+        <translation type="vanished">Çok fazla TRACE notu eklendi. Geri kalanlar dikkate alınmayacaktır.</translation>
+    </message>
+    <message>
+        <source>Too many notes added. The rest will be discarded.</source>
+        <translation type="vanished">Çok fazla not eklendi. Geri kalanlar dikkate alınmayacaktır.</translation>
+    </message>
+    <message>
+        <source>Too many streams found. Aborting processing.</source>
+        <translation type="vanished">Çok fazla akış tespit edildi. İşleyiş iptal ediliyor.</translation>
+    </message>
+    <message>
+        <source>Unsupported stream found. It may be supported in the future if there&apos;s a real need for it.</source>
+        <translation type="vanished">Desteklenmeyen akış tespit edildi. Gelecekte, gerçekten ihtiyaç duyulması halinde desteklenebilir.</translation>
+    </message>
+    <message>
+        <source>The file was saved using the &quot;fast&quot; option. While this improves the saving speed, it may leave the notes in an inconsistent state, so you should rescan the file.</source>
+        <translation type="vanished">Dosya &quot;hızlı&quot; seçeneği kullanılarak kaydedilmiştir. Bu, her ne kadar kayıt süresini iyileştirse dahi, notları tutarsız bir durumda bırakabilir; dolayısıyla dosyayı tekrar taramanız tavsiye edilir.</translation>
+    </message>
+    <message>
+        <source>An error occurred while reading the file, so it wasn&apos;t fully processed. This usually happens when reading from external drives or USB sticks, in which case a workaround might be to copy the files to an internal drive.</source>
+        <translation type="vanished">Dosya okunurken bir hata meydana geldi, dolayısıyla tamamen işlenemedi. Bu genelde harici sürücülerden veya USB belleklerden okunurken meydana gelir, bu durumda geçici bir çözüm olarak dosyaları dahili bir sürücüye kopyalamak düşünülebilir.</translation>
+    </message>
+</context>
+<context>
+    <name>NotesModel</name>
+    <message>
+        <location filename="../NotesModel.cpp" line="101"/>
+        <source>L</source>
+        <translation>L</translation>
+    </message>
+    <message>
+        <location filename="../NotesModel.cpp" line="102"/>
+        <source>Note</source>
+        <translation>Not</translation>
+    </message>
+    <message>
+        <location filename="../NotesModel.cpp" line="103"/>
+        <source>Address</source>
+        <translation>Adres</translation>
+    </message>
+</context>
+<context>
+    <name>PaletteDlg</name>
+    <message>
+        <location filename="../Palette.ui" line="14"/>
+        <source>Background colors</source>
+        <translation>Zemin renkleri</translation>
+    </message>
+    <message>
+        <location filename="../Palette.ui" line="26"/>
+        <source>Album</source>
+        <translation>Albüm</translation>
+    </message>
+    <message>
+        <location filename="../Palette.ui" line="54"/>
+        <source>Field equal to the ID3V2 field or missing</source>
+        <translation>ID3V2 alanına eşit veya eksik bir alan</translation>
+    </message>
+    <message>
+        <location filename="../Palette.ui" line="83"/>
+        <source>Field is different from the corresponding ID3V2 value (or no ID3V2 field exists)</source>
+        <translation>Alanın değeri, ilişkili ID3V2 değerinden farklı (veya hiçbir ID3V2 alanı yok)</translation>
+    </message>
+    <message>
+        <location filename="../Palette.ui" line="112"/>
+        <source>Value marked as &quot;assigned&quot;</source>
+        <translation>&quot;Atanmış&quot; olarak işaretlenmiş değer</translation>
+    </message>
+    <message>
+        <location filename="../Palette.ui" line="128"/>
+        <source>Song</source>
+        <translation>Şarkı</translation>
+    </message>
+    <message>
+        <location filename="../Palette.ui" line="156"/>
+        <source>Tag and field present</source>
+        <translation>Mevcut etiket ve alan</translation>
+    </message>
+    <message>
+        <location filename="../Palette.ui" line="185"/>
+        <source>Tag not present</source>
+        <translation>Etiket mevcut değil</translation>
+    </message>
+    <message>
+        <location filename="../Palette.ui" line="214"/>
+        <source>Tag present but field is not supported</source>
+        <translation>Etiket mevcut fakat desteklenmeyen alan</translation>
+    </message>
+    <message>
+        <location filename="../Palette.ui" line="243"/>
+        <source>Tag present, field is supported but missing</source>
+        <translation>Etiket mevcut, alan destekleniyor fakat eksik</translation>
+    </message>
+    <message>
+        <location filename="../Palette.ui" line="285"/>
+        <source>OK</source>
+        <translation>Tamam</translation>
+    </message>
+</context>
+<context>
+    <name>PatternsDlg</name>
+    <message>
+        <location filename="../Patterns.ui" line="14"/>
+        <source>Patterns</source>
+        <translation>Örüntüler</translation>
+    </message>
+    <message>
+        <location filename="../Patterns.ui" line="55"/>
+        <source>Add predefined patterns</source>
+        <translation>Önceden tanımlanmış örüntüler ekle</translation>
+    </message>
+    <message>
+        <location filename="../Patterns.ui" line="91"/>
+        <source>Line 1, Col 1</source>
+        <translation>Satır 1, Sütun 1</translation>
+    </message>
+    <message>
+        <location filename="../Patterns.ui" line="111"/>
+        <source>O&amp;K</source>
+        <translation>T&amp;amam</translation>
+    </message>
+    <message>
+        <location filename="../Patterns.ui" line="118"/>
+        <source>Cancel</source>
+        <translation>İptal et</translation>
+    </message>
+</context>
+<context>
+    <name>Renamer</name>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="1094"/>
+        <source>A pattern cannot be empty</source>
+        <translation>Örüntü boş olamaz</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="1101"/>
+        <source>A pattern must either begin with &apos;%1&apos; or contain no &apos;%1&apos; at all</source>
+        <translation>Örüntü ya &apos;%1&apos; ile başlamalı ya da hiçbir &apos;%1&apos; içermemelidir</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="1107"/>
+        <location filename="../FileRenamerDlgImpl.cpp" line="1111"/>
+        <source>A pattern must either begin with &quot;&lt;drive&gt;:\&quot; or contain no &apos;\&apos; at all</source>
+        <translation>Örüntü ya &quot;&lt;sürücü&gt;:\&quot;&apos; ile başlamalı ya da hiçbir &apos;\&apos; içermemelidir</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="1169"/>
+        <source>Error in column %1.</source>
+        <translation>%1 numaralı sütunda hata.</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="1178"/>
+        <source>Nested optional elements are not allowed</source>
+        <translation>İsteğe bağlı iç içe unsurlara izin verilmez</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="1187"/>
+        <source>Trying to close and optional element although none is open</source>
+        <translation>Seçime dayalı bir unsur kapatılmaya çalışılıyor halbuki hiçbiri açık değil</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="1201"/>
+        <source>Optional element must be closed</source>
+        <translation>Seçime dayalı unsur kapatılmalıdır</translation>
+    </message>
+    <message>
+        <location filename="../FileRenamerDlgImpl.cpp" line="1203"/>
+        <source>Title entry (%t) must be present</source>
+        <translation>Başlık girişi (%t) mevcut olmalıdır</translation>
+    </message>
+</context>
+<context>
+    <name>RenamerPatternsDlgImpl</name>
+    <message>
+        <location filename="../RenamerPatternsDlgImpl.cpp" line="50"/>
+        <source>%n	track number
+%a	artist
+%t	title
+%b	album
+%y	year
+%g	genre
+%r	rating (a lowercase letter)
+%c	composer
+
+To include the special characters &quot;%&quot;, &quot;[&quot; and &quot;]&quot;, precede them by a &quot;%&quot;: &quot;%%&quot;, &quot;%[&quot; and &quot;%]&quot;
+
+The path should be either a full path, starting with a &quot;%1&quot;, or it should contain no &quot;%1&quot;, if what is wanted is for the renamed files to remain in their original directories</source>
+        <translation>%n	parça sayısı
+%a	sanatçı
+%t	başlık
+%b	albüm
+%y	sene
+%g	tür
+%r	not (küçük bir harf)
+%c	bestekâr
+
+&quot;%&quot;, &quot;[&quot; ve &quot;]&quot; karakterlerini dahil etmek için ön ek olarak &quot;%&quot;: &quot;%%&quot;, &quot;%[&quot; ve &quot;%]&quot; kullanın
+
+İstenen şey, yeniden adlandırılan dosyaların orijinal dizinlerinde kalması ise erişim yolu ya &quot;%1&quot; ile başlayan ya da hiçbir &quot;%1&quot; içermeyen tam bir yol olmalıdır</translation>
+    </message>
+    <message>
+        <location filename="../RenamerPatternsDlgImpl.cpp" line="54"/>
+        <source>%n	track number
+%a	artist
+%t	title
+%b	album
+%y	year
+%g	genre
+%r	rating (a lowercase letter)
+%c	composer
+
+To include the special characters &quot;%&quot;, &quot;[&quot; and &quot;]&quot;, precede them by a &quot;%&quot;: &quot;%%&quot;, &quot;%[&quot; and &quot;%]&quot;
+
+The path should be either a full path, starting with a drive letter followed by &quot;:\&quot;, or it should contain no &quot;\&quot;, if what is wanted is for the renamed files to remain in their original directories</source>
+        <translation>%n	parça sayısı
+%a	sanatçı
+%t	başlık
+%b	albüm
+%y	sene
+%g	tür
+%r	not (küçük bir harf)
+%c	bestekâr
+
+&quot;%&quot;, &quot;[&quot; ve &quot;]&quot; karakterlerini dahil etmek için ön ek olarak &quot;%&quot;: &quot;%%&quot;, &quot;%[&quot; ve &quot;%]&quot; kullanın
+
+İstenen şey, yeniden adlandırılan dosyaların orijinal dizinlerinde kalması ise erişim yolu ya sürücü harfi ve ardından &quot;:\&quot; ile başlayan ya da hiçbir &quot;\&quot; içermeyen tam bir yol olmalıdır</translation>
+    </message>
+    <message>
+        <location filename="../RenamerPatternsDlgImpl.cpp" line="107"/>
+        <source>Error</source>
+        <translation>Hata</translation>
+    </message>
+    <message>
+        <location filename="../RenamerPatternsDlgImpl.cpp" line="177"/>
+        <source>Line %1, Col %2</source>
+        <translation>Satır %1, Sütun %2</translation>
+    </message>
+</context>
+<context>
+    <name>ScanDlg</name>
+    <message>
+        <location filename="../Scan.ui" line="14"/>
+        <source>Scan</source>
+        <translation>Tara</translation>
+    </message>
+    <message>
+        <location filename="../Scan.ui" line="31"/>
+        <source>Rescan files that seem unchanged</source>
+        <translation>Değiştirilmemiş gibi duran dosyaları tekrar tara</translation>
+    </message>
+    <message>
+        <location filename="../Scan.ui" line="53"/>
+        <source>&amp;Scan</source>
+        <translation>&amp;Tara</translation>
+    </message>
+    <message>
+        <location filename="../Scan.ui" line="60"/>
+        <source>Cancel</source>
+        <translation>İptal et</translation>
+    </message>
+</context>
+<context>
+    <name>SessionEditorDlg</name>
+    <message>
+        <location filename="../SessionEditor.ui" line="14"/>
+        <source>pppppppppppppp</source>
+        <translation>pppppppppppppp</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditor.ui" line="48"/>
+        <source>Language</source>
+        <translation>Lisan</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditor.ui" line="68"/>
+        <source>Include directories</source>
+        <translation>Dahil edilecek dizinler</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditor.ui" line="78"/>
+        <source>Backup</source>
+        <translation>Yedekleme</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditor.ui" line="87"/>
+        <source>Don&apos;t create backup for modified files</source>
+        <translation>Değiştirilmiş dosyalar için yedekleme yapma</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditor.ui" line="94"/>
+        <source>Create backup for modified files in</source>
+        <translation>Değiştirilmiş dosyalar için şurada yedekleme yap</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditor.ui" line="108"/>
+        <location filename="../SessionEditor.ui" line="134"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditor.ui" line="120"/>
+        <source>Settings file name</source>
+        <translation>Yapılandırma dosyası ismi</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditor.ui" line="143"/>
+        <source>Scan for new, modified, and deleted files at startup</source>
+        <translation>Başlangıçta yeni, değiştirilmiş ve silinmiş dosyaları için tarama yap</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditor.ui" line="153"/>
+        <source>Open last session at s&amp;tartup</source>
+        <translation>Ba&amp;şlangıçta son oturumu aç</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditor.ui" line="165"/>
+        <source>Open the main &quot;Sessions&quot; dialog, to load an existing session</source>
+        <translation>Mevcut bir oturumu yüklemek için ana &quot;Oturumlar&quot; diyaloğunu aç</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditor.ui" line="185"/>
+        <source>O&amp;K</source>
+        <translation>T&amp;amam</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditor.ui" line="195"/>
+        <source>Cancel</source>
+        <translation>İptal et</translation>
+    </message>
+</context>
+<context>
+    <name>SessionEditorDlgImpl</name>
+    <message>
+        <location filename="../SessionEditorDlgImpl.cpp" line="137"/>
+        <source>This is the name of the &quot;settings file&quot;
+
+It is supposed to be a file that doesn&apos;t already exist. You don&apos;t need to set it up. MP3 Diags
+will store its settings in this file.
+
+The name was generated automatically. If you want to choose a different name, simply click on
+the button at the right to change it.</source>
+        <comment>this is a multiline tooltip</comment>
+        <translation>Bu, &quot;yapılandırma dosyasının&quot; ismidir.
+
+Bunun henüz mevcut olmayan bir dosya olması beklenir. Onu oluşturmaya ihtiyacınız yoktur. 
+MP3 Diags ayarlarını bu dosyada saklayacaktır.
+
+İsmi otomatik olarak oluşturulmuştur. Başka bir isim seçmek istiyorsanız, değiştirmek için sağdaki
+düğmeye tıklamanız yeterli olacaktır.</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditorDlgImpl.cpp" line="143"/>
+        <source>Here you need to specify the name of a &quot;settings file&quot;
+
+This is supposed to be a file that doesn&apos;t already exist. You don&apos;t need to set it up. MP3 Diags
+will store its settings in this file.
+
+To change it, simply click on the button at the right to choose the name of the settings file.</source>
+        <comment>this is a multiline tooltip</comment>
+        <translation>Burada bir &quot;yapılandırma dosyasının&quot; ismini belirtmeniz gerekmektedir.
+
+Bunun henüz mevcut olmayan bir dosya olması beklenir. Onu oluşturmaya ihtiyacınız yoktur. 
+MP3 Diags ayarlarını bu dosyada saklayacaktır.
+
+Onu değiştirmek için yapılandırma dosyasının ismini seçmek maksadıyla sağdaki düğmeye
+tıklamanız yeterli olacaktır.</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditorDlgImpl.cpp" line="216"/>
+        <source>MP3 Diags - Create new session</source>
+        <translation>MP3 Diags - Yeni oturum oluştur</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditorDlgImpl.cpp" line="216"/>
+        <source>MP3 Diags - Edit session</source>
+        <translation>MP3 Diags - Oturumu düzenle</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditorDlgImpl.cpp" line="250"/>
+        <location filename="../SessionEditorDlgImpl.cpp" line="260"/>
+        <location filename="../SessionEditorDlgImpl.cpp" line="269"/>
+        <location filename="../SessionEditorDlgImpl.cpp" line="316"/>
+        <source>Error</source>
+        <translation>Hata</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditorDlgImpl.cpp" line="250"/>
+        <source>You need to specify the name of the settings file.
+
+This is supposed to be a file that doesn&apos;t already exist. You don&apos;t need to set it up, but just to pick a name for it. MP3 Diags will store its settings in this file.</source>
+        <translation>Yapılandırma dosyasının ismini belirtmeniz gerekmektedir.
+
+Bunun henüz mevcut olmayan bir dosya olması beklenir. Onu oluşturmaya ihtiyacınız yoktur. MP3 Diags ayarlarını bu dosyada saklayacaktır.</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditorDlgImpl.cpp" line="260"/>
+        <source>You need to select at least a directory to be included in the session.</source>
+        <translation>Bu oturuma dahil edilecek en az bir bizin seçmeniz gerekmektedir.</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditorDlgImpl.cpp" line="269"/>
+        <source>If you want to create backups, you must select an existing directory to store them.</source>
+        <translation>Şayet yedekleme yapmak istiyorsanız, bunu saklamak için mevcut bir dizin seçmeniz gerekmektedir.</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditorDlgImpl.cpp" line="316"/>
+        <source>Failed to write to file %1</source>
+        <translation>%1 dosyasına yazma başarısız oldu</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditorDlgImpl.cpp" line="341"/>
+        <source>Select folder</source>
+        <translation>Dizin seç</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditorDlgImpl.cpp" line="341"/>
+        <source>All files (*)</source>
+        <translation>Tüm dosyalar (*)</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditorDlgImpl.cpp" line="381"/>
+        <location filename="../SessionEditorDlgImpl.cpp" line="386"/>
+        <source>Enter configuration file</source>
+        <translation>Yapılandırma dosyasını gir</translation>
+    </message>
+    <message>
+        <location filename="../SessionEditorDlgImpl.cpp" line="381"/>
+        <location filename="../SessionEditorDlgImpl.cpp" line="386"/>
+        <location filename="../SessionsDlgImpl.cpp" line="453"/>
+        <location filename="../SessionsDlgImpl.cpp" line="495"/>
+        <source>MP3 Diags session files (*%1)</source>
+        <translation>MP3 Diags oturum dosyaları (*%1)</translation>
+    </message>
+</context>
+<context>
+    <name>SessionsDlg</name>
+    <message>
+        <location filename="../Sessions.ui" line="14"/>
+        <source>MP3 Diags - Sessions</source>
+        <translation>MP3 Diags - Oturumlar</translation>
+    </message>
+    <message>
+        <location filename="../Sessions.ui" line="48"/>
+        <source>Language</source>
+        <translation>Lisan</translation>
+    </message>
+    <message>
+        <location filename="../Sessions.ui" line="104"/>
+        <source>&amp;Open</source>
+        <translation>&amp;Aç</translation>
+    </message>
+    <message>
+        <location filename="../Sessions.ui" line="114"/>
+        <source>&amp;New ...</source>
+        <translation>&amp;Yeni ...</translation>
+    </message>
+    <message>
+        <location filename="../Sessions.ui" line="121"/>
+        <source>&amp;Edit ...</source>
+        <translation>&amp;Düzenle ...</translation>
+    </message>
+    <message>
+        <location filename="../Sessions.ui" line="128"/>
+        <source>Save &amp;as ...</source>
+        <translation>Farklı &amp;kaydet ...</translation>
+    </message>
+    <message>
+        <location filename="../Sessions.ui" line="135"/>
+        <source>E&amp;rase</source>
+        <translation>&amp;Sil</translation>
+    </message>
+    <message>
+        <location filename="../Sessions.ui" line="142"/>
+        <source>&amp;Load ...</source>
+        <translation>Y&amp;ükle ...</translation>
+    </message>
+    <message>
+        <location filename="../Sessions.ui" line="149"/>
+        <source>&amp;Hide</source>
+        <translation>&amp;Gizle</translation>
+    </message>
+    <message>
+        <location filename="../Sessions.ui" line="156"/>
+        <source>Close</source>
+        <translation>Kapat</translation>
+    </message>
+    <message>
+        <location filename="../Sessions.ui" line="196"/>
+        <source>Temporary session template</source>
+        <translation>Geçici oturumlar için şablon</translation>
+    </message>
+    <message>
+        <location filename="../Sessions.ui" line="222"/>
+        <source>Persistent session template</source>
+        <translation>Kalıcı oturumlar için şablon</translation>
+    </message>
+    <message>
+        <location filename="../Sessions.ui" line="258"/>
+        <source>At s&amp;tartup open the last session automatically</source>
+        <translation>&amp;Başlangıçta otomatik olarak son oturumu aç</translation>
+    </message>
+</context>
+<context>
+    <name>SessionsDlgImpl</name>
+    <message>
+        <location filename="../SessionsDlgImpl.cpp" line="203"/>
+        <location filename="../SessionsDlgImpl.cpp" line="204"/>
+        <source>&lt;last session&gt;</source>
+        <translation>&lt;son oturum&gt;</translation>
+    </message>
+    <message>
+        <location filename="../SessionsDlgImpl.cpp" line="424"/>
+        <location filename="../SessionsDlgImpl.cpp" line="487"/>
+        <source>Confirm</source>
+        <translation>Teyit et</translation>
+    </message>
+    <message>
+        <location filename="../SessionsDlgImpl.cpp" line="424"/>
+        <source>Do you really want to erase the current session?</source>
+        <translation>Güncel oturumu hakikaten silmek istiyor musunuz?</translation>
+    </message>
+    <message>
+        <location filename="../SessionsDlgImpl.cpp" line="424"/>
+        <source>Erase</source>
+        <translation>Sil</translation>
+    </message>
+    <message>
+        <location filename="../SessionsDlgImpl.cpp" line="424"/>
+        <location filename="../SessionsDlgImpl.cpp" line="487"/>
+        <source>Cancel</source>
+        <translation>İptal et</translation>
+    </message>
+    <message>
+        <location filename="../SessionsDlgImpl.cpp" line="441"/>
+        <location filename="../SessionsDlgImpl.cpp" line="510"/>
+        <location filename="../SessionsDlgImpl.cpp" line="523"/>
+        <source>Error</source>
+        <translation>Hata</translation>
+    </message>
+    <message>
+        <location filename="../SessionsDlgImpl.cpp" line="441"/>
+        <source>Failed to remove the data files associated with this session</source>
+        <translation>Bu oturumla ilişkili veri dosyalarının kaldırılmaları başarısız oldu</translation>
+    </message>
+    <message>
+        <location filename="../SessionsDlgImpl.cpp" line="453"/>
+        <source>Save session as ...</source>
+        <translation>Oturumu farklı kaydet ...</translation>
+    </message>
+    <message>
+        <location filename="../SessionsDlgImpl.cpp" line="487"/>
+        <source>Do you really want to hide the current session?</source>
+        <translation>Güncel oturumu hakikaten gizlemek istiyor musunuz?</translation>
+    </message>
+    <message>
+        <location filename="../SessionsDlgImpl.cpp" line="487"/>
+        <source>Hide</source>
+        <translation>Gizle</translation>
+    </message>
+    <message>
+        <location filename="../SessionsDlgImpl.cpp" line="495"/>
+        <source>Choose a session file</source>
+        <translation>Bir oturum dosyası seç</translation>
+    </message>
+    <message>
+        <location filename="../SessionsDlgImpl.cpp" line="510"/>
+        <source>The session named &quot;%1&quot; is already part of the session list</source>
+        <translation>&quot;%1&quot; isimli oturum zaten oturum listesinin bir parçasıdır</translation>
+    </message>
+    <message>
+        <location filename="../SessionsDlgImpl.cpp" line="523"/>
+        <source>The session list is empty. You must create a new session or load an existing one.</source>
+        <translation>Oturum listesi boştur. Yeni bir oturum oluşturmanız veya mevcut bir oturumu yüklemeniz gerekmektedir.</translation>
+    </message>
+</context>
+<context>
+    <name>SessionsModel</name>
+    <message>
+        <location filename="../SessionsDlgImpl.cpp" line="73"/>
+        <source>File name</source>
+        <translation>Dosya ismi</translation>
+    </message>
+</context>
+<context>
+    <name>ShellIntegrator</name>
+    <message>
+        <location filename="../Helpers.cpp" line="1200"/>
+        <source>%1 - %2</source>
+        <translation>%1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../Helpers.cpp" line="1282"/>
+        <source>Error setting up shell integration</source>
+        <translation>Kabuk birleşimi yapılandırması esnasında hata</translation>
+    </message>
+    <message>
+        <location filename="../Helpers.cpp" line="1282"/>
+        <source>It appears that setting up shell integration didn&apos;t complete successfully. You might have to configure it manually.</source>
+        <translation>Kabuk birleşimi yapılandırması başarılı bir şekilde sonlanmadı gibi görünüyor. Bunu el ile yapılandırmanız gerekebilir.</translation>
+    </message>
+    <message>
+        <location filename="../Helpers.cpp" line="1283"/>
+        <source>This message will not be shown again until the program is restarted, even if more errors occur.</source>
+        <translation>Bu mesaj programın tekrar başlatılmasına dek yeniden gösterilmeyecektir, daha fazla hata meydana gelse bile.</translation>
+    </message>
+    <message>
+        <location filename="../Helpers.cpp" line="1284"/>
+        <source>O&amp;K</source>
+        <translation>T&amp;amam</translation>
+    </message>
+    <message>
+        <location filename="../Helpers.cpp" line="1304"/>
+        <source>temporary folder</source>
+        <translation>geçici dizin</translation>
+    </message>
+    <message>
+        <location filename="../Helpers.cpp" line="1305"/>
+        <source>hidden folder</source>
+        <translation>gizli dizin</translation>
+    </message>
+    <message>
+        <location filename="../Helpers.cpp" line="1306"/>
+        <source>visible folder</source>
+        <translation>görünür dizin</translation>
+    </message>
+</context>
+<context>
+    <name>StreamsModel</name>
+    <message>
+        <location filename="../StreamsModel.cpp" line="133"/>
+        <source>Address</source>
+        <translation>Adres</translation>
+    </message>
+    <message>
+        <location filename="../StreamsModel.cpp" line="134"/>
+        <source>Size (dec)</source>
+        <translation>Boyut (ondalık)</translation>
+    </message>
+    <message>
+        <location filename="../StreamsModel.cpp" line="135"/>
+        <source>Size (hex)</source>
+        <translation>Boyut (onaltılık)</translation>
+    </message>
+    <message>
+        <location filename="../StreamsModel.cpp" line="136"/>
+        <source>Type</source>
+        <translation>Tür</translation>
+    </message>
+    <message>
+        <location filename="../StreamsModel.cpp" line="137"/>
+        <source>Stream details</source>
+        <translation>Akış ayrıntıları</translation>
+    </message>
+</context>
+<context>
+    <name>TagEditor::CurrentAlbumDelegate</name>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1949"/>
+        <source>Warning</source>
+        <translation>İkaz</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1949"/>
+        <source>You are editing data in a cell. If you proceed that change will be lost. Proceed and lose the data?</source>
+        <translation>Bir hücrede veri düzenlemektesiniz. Devam ederseniz bu değişiklik kaybolacaktır. Devam edilip veriler kaybedilsin mi?</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1949"/>
+        <source>Proceed</source>
+        <translation>Devam et</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1949"/>
+        <source>Cancel</source>
+        <translation>İptal et</translation>
+    </message>
+</context>
+<context>
+    <name>TagEditor::CurrentAlbumModel</name>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="98"/>
+        <source>N/A</source>
+        <translation>Yok</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="140"/>
+        <source>File name</source>
+        <translation>Dosya ismi</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="168"/>
+        <source>Error</source>
+        <translation>Hata</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="168"/>
+        <source>The data contained errors and couldn&apos;t be saved</source>
+        <translation>Veriler hatalar içeriyordu ve kaydedilemediler</translation>
+    </message>
+</context>
+<context>
+    <name>TagEditor::CurrentFileModel</name>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="205"/>
+        <source>N/A</source>
+        <translation>Yok</translation>
+    </message>
+</context>
+<context>
+    <name>TagEditorDlg</name>
+    <message>
+        <location filename="../TagEditor.ui" line="14"/>
+        <source>MP3 Diags - Tag editor</source>
+        <translation>MP3 Diags - Etiket düzenleyici</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="47"/>
+        <source>Save</source>
+        <translation>Kaydet</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="50"/>
+        <source>S</source>
+        <translation>K</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="85"/>
+        <source>Reset</source>
+        <translation>Sıfırla</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="88"/>
+        <source>R</source>
+        <translation>S</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="139"/>
+        <source>Previous [Ctrl+P]</source>
+        <translation>Önceki [Ctrl+P]</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="142"/>
+        <source>&lt;</source>
+        <translation>&lt;</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="155"/>
+        <source>Ctrl+P</source>
+        <translation>Ctrl+P</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="184"/>
+        <source>Folder</source>
+        <translation>Dizin</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="225"/>
+        <source>Next [Ctrl+N]</source>
+        <translation>Sonraki [Ctrl+N]</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="228"/>
+        <source>&gt;</source>
+        <translation>&gt;</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="241"/>
+        <source>Ctrl+N</source>
+        <translation>Ctrl+N</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="285"/>
+        <source>Query Discogs</source>
+        <translation>Discogs&apos;ı sorgula</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="288"/>
+        <source>Q</source>
+        <translation>Q</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="323"/>
+        <source>Query MusicBrainz</source>
+        <translation>MusicBrainz&apos;i sorgula</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="326"/>
+        <location filename="../TagEditor.ui" line="418"/>
+        <location filename="../TagEditor.ui" line="494"/>
+        <location filename="../TagEditor.ui" line="570"/>
+        <location filename="../TagEditor.ui" line="665"/>
+        <location filename="../TagEditor.ui" line="703"/>
+        <location filename="../TagEditor.ui" line="741"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="377"/>
+        <source>Toggle &quot;Various Artists&quot;</source>
+        <translation>&quot;Çeşitli Sanatçıları&quot; görüntüle/gizle</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="380"/>
+        <source>V</source>
+        <translation>V</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="415"/>
+        <source>Change case automatically</source>
+        <translation>Büyük/küçük harfi otomatik değiştir</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="453"/>
+        <source>Copy field(s) from first line</source>
+        <translation>Alan(lar)ı ilk satırdan kopyala</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="456"/>
+        <source>C</source>
+        <translation>C</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="491"/>
+        <source>Sort by track number</source>
+        <translation>Parça numarasına göre sırala</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="529"/>
+        <source>Toggle &quot;assigned&quot; state</source>
+        <translation>&quot;Atanmış&quot; durumu görüntüle/gizle</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="532"/>
+        <source>A</source>
+        <translation>A</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="567"/>
+        <source>Paste</source>
+        <translation>Yapıştır</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="583"/>
+        <source>Ctrl+V</source>
+        <translation>Ctrl+V</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="608"/>
+        <source>Edit file patterns</source>
+        <translation>Dosya örüntülerini düzenle</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="611"/>
+        <source>F</source>
+        <translation>F</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="662"/>
+        <source>Background colors</source>
+        <translation>Zemin renkleri</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="700"/>
+        <source>Configuration</source>
+        <translation>Yapılandırma</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="738"/>
+        <source>Close</source>
+        <translation>Kapat</translation>
+    </message>
+    <message>
+        <location filename="../TagEditor.ui" line="785"/>
+        <location filename="../TagEditor.ui" line="823"/>
+        <source>TextLabel</source>
+        <translation>TextLabel</translation>
+    </message>
+</context>
+<context>
+    <name>TagEditorDlgImpl</name>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="513"/>
+        <source>Toggle &quot;Various Artists&quot;</source>
+        <translation>&quot;Çeşitli Sanatçıları&quot; görüntüle/gizle</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="515"/>
+        <source>To enable &quot;Various Artists&quot; you need to open the
+configuration dialog, go to the &quot;Others&quot; tab and
+check the corresponding checkbox(es)</source>
+        <comment>this is a multi-line tooltip</comment>
+        <translation>&quot;Çeşitli Sanatçıları&quot; etkinleştirmek için yapılandırma
+penceresini açıp &quot;Diğerleri&quot; sekmesindeki alakalı
+kutucukları işaretlemeniz gerekmektedir</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="898"/>
+        <source>Error setting up the tag order</source>
+        <translation>Etiket sıralaması yapılandırmasında hata</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="898"/>
+        <source>An invalid value was found in the configuration file. You&apos;ll have to sort the tags again.</source>
+        <translation>Yapılandırma dosyasında geçersiz bir değer tespit edildi. Etiketleri tekrar sıralamanız gerekecektir.</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="962"/>
+        <source>Error setting up patterns</source>
+        <translation>Örüntülerin yapılandırılmalarında hata</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="962"/>
+        <source>An invalid value was found in the configuration file. You&apos;ll have to set up the patterns manually.</source>
+        <translation>Yapılandırma dosyasında geçersiz bir değer tespit edildi. Örüntüleri el ile yapılandırmanız gerekecektir.</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1033"/>
+        <source>Warning</source>
+        <translation>İkaz</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1033"/>
+        <source>Reloading the current album causes all unsaved changes to be lost. Really reload?</source>
+        <translation>Güncel albümü tekrar yüklemek kaydedilmemiş tüm değişikliklerin kaybolmasına yol açacaktır. Hakikaten tekrar yüklensin mi?</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1033"/>
+        <source>Reload</source>
+        <translation>Tekrar yükle</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1033"/>
+        <source>Cancel</source>
+        <translation>İptal et</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1068"/>
+        <source>Artists - %1</source>
+        <translation>Sanatçılar - %1</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1073"/>
+        <source>Others - %1</source>
+        <translation>Diğerleri - %1</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1698"/>
+        <location filename="../TagEditorDlgImpl.cpp" line="1719"/>
+        <location filename="../TagEditorDlgImpl.cpp" line="1723"/>
+        <location filename="../TagEditorDlgImpl.cpp" line="1727"/>
+        <source>Confirm</source>
+        <translation>Teyit et</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1698"/>
+        <source>You added %1 images but then you didn&apos;t assign them to any songs. What do you want to do?</source>
+        <translation>%1 resim eklediniz fakat bunları hiçbir şarkıya atamadınız. Ne yapmak istiyorsunuz?</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1698"/>
+        <source>You added an image but then you didn&apos;t assign it to any song. What do you want to do?</source>
+        <translation>Bir resim eklediniz fakat bunu hiçbir şarkıya atamadınız. Ne yapmak istiyorsunuz?</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1698"/>
+        <location filename="../TagEditorDlgImpl.cpp" line="1719"/>
+        <location filename="../TagEditorDlgImpl.cpp" line="1723"/>
+        <location filename="../TagEditorDlgImpl.cpp" line="1727"/>
+        <source>&amp;Discard</source>
+        <translation>&amp;Dikkate alma</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1698"/>
+        <location filename="../TagEditorDlgImpl.cpp" line="1719"/>
+        <location filename="../TagEditorDlgImpl.cpp" line="1723"/>
+        <location filename="../TagEditorDlgImpl.cpp" line="1727"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;İptal et</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1719"/>
+        <source>There are unsaved fields that you assigned a value to, as well as fields whose value doesn&apos;t match the ID3V2 value. What do you want to do?</source>
+        <translation>Değer atadığınız kaydedilmemiş alanlar mevcuttur, aynı zamanda değerleri ID3v2 değeriyle eşleşmeyen alanlar da mevcuttur. Ne yapmak istiyorsunuz?</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1719"/>
+        <location filename="../TagEditorDlgImpl.cpp" line="1723"/>
+        <location filename="../TagEditorDlgImpl.cpp" line="1727"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Kaydet</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1723"/>
+        <source>There are unsaved fields that you assigned a value to. What do you want to do?</source>
+        <translation>Kaydedilmemiş ancak onlara bir değer atadığınız alanlar mevcuttur. Ne yapmak istiyorsunuz?</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1727"/>
+        <source>There are fields whose value doesn&apos;t match the ID3V2 value. What do you want to do?</source>
+        <translation>Değerleri ID3v2 değeriyle eşleşmeyen alanlar mevcuttur. Ne yapmak istiyorsunuz?</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1748"/>
+        <source>Saving ID3V2.3.0 tags</source>
+        <translation>ID3V2.3.0 etiketleri kaydediliyor</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1774"/>
+        <source>Info</source>
+        <translation>Bilgi</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1774"/>
+        <source>Some fields are missing or may be incomplete. While this is usually solved by downloading correct information, there are a cases when this approach doesn&apos;t work, like custom compilations, rare albums, or missing tracks.</source>
+        <translation>Bazı alanlar eksik veya tamamlanmamış olabilir. Her ne kadar bu durum doğru bilgilerin indirilmesiyle çözülebilse dahi, özel derlemeler, nadir albümler veya eksik parçalar gibi durumlarda bu yaklaşım işe yaramaz.</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1776"/>
+        <source>If your current folder fits one of these cases or you simply have consistently named files that you would prefer to use as a source of track info, you may want to take a look at the tag editor&apos;s patterns, at %1</source>
+        <translation>Eğer güncel dizininiz bu durumlardan birine tekabül ediyorsa veya parça bilgisi kaynağı olarak kullanmayı tercih ettiğiniz, tutarlı şekilde isimlendirilmiş dosyalarınız varsa, %1 konumdaki etiket düzenleyicisinin örüntülerine göz atmak isteyebilirsiniz</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1776"/>
+        <source>O&amp;K</source>
+        <translation>T&amp;amam</translation>
+    </message>
+</context>
+<context>
+    <name>TagEdtPatternsDlgImpl</name>
+    <message>
+        <source>%n	track number
+%a	artist
+%t	title
+%b	album
+%y	year
+%g	genre
+%r	rating (a lowercase letter)
+%c	composer
+%i	ignored
+
+To include the special characters &quot;%&quot;, &quot;[&quot;, &quot;]&quot; and &quot;%1&quot;, preced them by a &quot;%&quot;: &quot;%%&quot;, &quot;%[&quot;, &quot;%]&quot; and &quot;%%1&quot;
+
+For a pattern to be considered a &quot;file pattern&quot; (as opposed to a &quot;table pattern&quot;), it must contain at least a &quot;%1&quot;, even if you don&apos;t care about what&apos;s in the file&apos;s parent directory (see the fourth predefined pattern for an example.)
+
+Leading and trailing spaces are removed automatically from unbound fields after matching, so &quot;-[ ]%t&quot; is equivalent to &quot;-%t&quot; (but &quot;-[ ]%n&quot; is not equivalent to &quot;-%n&quot;, because %n is a fixed format field). However, all non-optional characters matter in the matching phase, including spaces.</source>
+        <translation type="vanished">%n	parça numarası
+%a	sanatçı
+%t	başlık
+%b	albüm
+%y	sene
+%g	tür
+%r	not (bir küçük harf)
+%c	bestekâr
+%i	dikkate alınmaz
+
+&quot;%&quot;, &quot;[&quot;, &quot;]&quot; et &quot;%1&quot; özel karakterleri dahil etmek için onları bir &quot;%&quot;: &quot;%%&quot;, &quot;%[&quot;, &quot;%]&quot; ve &quot;%%1&quot; ön eki ile kullanın
+
+Bir örüntünün &quot;dosya örüntüsü&quot; olarak kabul edilmesi için (tablo örüntüsüne zıt olarak), en az bir &quot;%1&quot; içermesi gerekir, üst dizinin içeriği sizin için önemli olmasa dahi (mesela ön tanımlı dördüncü örüntüye bakın.)
+
+Eşleştirmeden sonra, bağlı olmayan alanlardaki baştaki ve sondaki boşluklar otomatik olarak kaldırılır, bu nedenle &quot;-[ ]%t&quot; &quot;-%t&quot; ile eşdeğerdir (ancak &quot;-[ ]%n&quot; &quot;-%n&quot; ile eşdeğer değildir, çünkü %n sabit biçimli bir alandır). Bununla birlikte, boşluklar da dahil olmak üzere, isteğe bağlı olmayan tüm karakterler eşleştirme aşamasında önemlidir.</translation>
+    </message>
+    <message>
+        <location filename="../TagEdtPatternsDlgImpl.cpp" line="53"/>
+        <source>%n	track number
+%a	artist
+%t	title
+%b	album
+%y	year
+%g	genre
+%r	rating (a lowercase letter)
+%c	composer
+%i	ignored
+
+To include the special characters &quot;%&quot;, &quot;[&quot;, &quot;]&quot; and &quot;%1&quot;, precede them by a &quot;%&quot;: &quot;%%&quot;, &quot;%[&quot;, &quot;%]&quot; and &quot;%%1&quot;
+
+For a pattern to be considered a &quot;file pattern&quot; (as opposed to a &quot;table pattern&quot;), it must contain at least a &quot;%1&quot;, even if you don&apos;t care about what&apos;s in the file&apos;s parent directory (see the fourth predefined pattern for an example.)
+
+Leading and trailing spaces are removed automatically from unbound fields after matching, so &quot;-[ ]%t&quot; is equivalent to &quot;-%t&quot; (but &quot;-[ ]%n&quot; is not equivalent to &quot;-%n&quot;, because %n is a fixed format field). However, all non-optional characters matter in the matching phase, including spaces.</source>
+        <translation>%n	parça numarası
+%a	sanatçı
+%t	başlık
+%b	albüm
+%y	sene
+%g	tür
+%r	not (bir küçük harf)
+%c	bestekâr
+%i	dikkate alınmaz
+
+&quot;%&quot;, &quot;[&quot;, &quot;]&quot; et &quot;%1&quot; özel karakterleri dahil etmek için onları bir &quot;%&quot;: &quot;%%&quot;, &quot;%[&quot;, &quot;%]&quot; ve &quot;%%1&quot; ön eki ile kullanın
+
+Bir örüntünün &quot;dosya örüntüsü&quot; olarak kabul edilmesi için (tablo örüntüsüne zıt olarak), en az bir &quot;%1&quot; içermesi gerekir, üst dizinin içeriği sizin için önemli olmasa dahi (mesela ön tanımlı dördüncü örüntüye bakın.)
+
+Eşleştirmeden sonra, bağlı olmayan alanlardaki baştaki ve sondaki boşluklar otomatik olarak kaldırılır, bu nedenle &quot;-[ ]%t&quot; &quot;-%t&quot; ile eşdeğerdir (ancak &quot;-[ ]%n&quot; &quot;-%n&quot; ile eşdeğer değildir, çünkü %n sabit biçimli bir alandır). Bununla birlikte, boşluklar da dahil olmak üzere, isteğe bağlı olmayan tüm karakterler eşleştirme aşamasında önemlidir.</translation>
+    </message>
+    <message>
+        <location filename="../TagEdtPatternsDlgImpl.cpp" line="100"/>
+        <source>Error</source>
+        <translation>Hata</translation>
+    </message>
+    <message>
+        <location filename="../TagEdtPatternsDlgImpl.cpp" line="186"/>
+        <source>Line %1, Col %2</source>
+        <translation>Satır %1, Sütun %2</translation>
+    </message>
+</context>
+<context>
+    <name>TagReadPanel</name>
+    <message>
+        <location filename="../TagReadPanel.cpp" line="96"/>
+        <source>Track#</source>
+        <translation>Parça#</translation>
+    </message>
+    <message>
+        <location filename="../TagReadPanel.cpp" line="96"/>
+        <source>Artist</source>
+        <translation>Sanatçı</translation>
+    </message>
+    <message>
+        <location filename="../TagReadPanel.cpp" line="96"/>
+        <source>Title</source>
+        <translation>Başlık</translation>
+    </message>
+    <message>
+        <location filename="../TagReadPanel.cpp" line="96"/>
+        <source>Album</source>
+        <translation>Albüm</translation>
+    </message>
+    <message>
+        <location filename="../TagReadPanel.cpp" line="96"/>
+        <source>VA</source>
+        <translation>ÇS</translation>
+    </message>
+    <message>
+        <location filename="../TagReadPanel.cpp" line="96"/>
+        <source>Time</source>
+        <translation>Süre</translation>
+    </message>
+    <message>
+        <location filename="../TagReadPanel.cpp" line="96"/>
+        <source>Genre</source>
+        <translation>Tür</translation>
+    </message>
+    <message>
+        <location filename="../TagReadPanel.cpp" line="96"/>
+        <source>Rating</source>
+        <translation>Not</translation>
+    </message>
+    <message>
+        <location filename="../TagReadPanel.cpp" line="96"/>
+        <source>Composer</source>
+        <translation>Bestekâr</translation>
+    </message>
+</context>
+<context>
+    <name>TagReader</name>
+    <message>
+        <location filename="../ApeStream.cpp" line="161"/>
+        <location filename="../Id3V230Stream.cpp" line="213"/>
+        <location filename="../Id3V240Stream.cpp" line="348"/>
+        <source>&lt;non-text value&gt;</source>
+        <translation>&lt;metin olmayan değer&gt;</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="108"/>
+        <source>other</source>
+        <translation>diğer</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="109"/>
+        <source>32x32 icon</source>
+        <translation>32x32 ikon</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="110"/>
+        <source>other file icon</source>
+        <translation>diğer dosya ikonu</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="111"/>
+        <source>front cover</source>
+        <translation>ön kapak</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="112"/>
+        <source>back cover</source>
+        <translation>arka kapak</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="113"/>
+        <source>leaflet page</source>
+        <translation>kitapçık sayfası</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="114"/>
+        <source>media</source>
+        <translation>ortam</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="115"/>
+        <source>lead artist</source>
+        <translation>baş sanatçı</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="116"/>
+        <source>artist</source>
+        <translation>sanatçı</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="117"/>
+        <source>conductor</source>
+        <translation>orkestra şefi</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="118"/>
+        <source>band</source>
+        <translation>grup</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="119"/>
+        <source>composer</source>
+        <translation>bestekâr</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="120"/>
+        <source>lyricist</source>
+        <translation>güfteci</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="121"/>
+        <source>recording location</source>
+        <translation>kayıt yeri</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="122"/>
+        <source>during recording</source>
+        <translation>kayıt esnasında</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="123"/>
+        <source>during performance</source>
+        <translation>konser esnasında</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="124"/>
+        <source>screen capture</source>
+        <translation>ekran fotoğrafı</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="126"/>
+        <source>illustration</source>
+        <translation>çizim</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="127"/>
+        <source>band/artist logotype</source>
+        <translation>sanatçı/grup logosu</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="128"/>
+        <source>publisher/studio logotype</source>
+        <translation>yayıncı/stüdyo logosu</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="130"/>
+        <source>unknown</source>
+        <translation>bilinmiyor</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="436"/>
+        <source>&lt;no change&gt;</source>
+        <translation>&lt;değiştirilmemiş&gt;</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="437"/>
+        <source>lower case</source>
+        <translation>küçük harfler</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="438"/>
+        <source>UPPER CASE</source>
+        <translation>BÜYÜK HARFLER</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="439"/>
+        <source>Title Case</source>
+        <translation>Başlık büyük veya küçük harfleri</translation>
+    </message>
+    <message>
+        <location filename="../CommonTypes.cpp" line="440"/>
+        <source>Sentence case</source>
+        <translation>Cümle büyük veya küçük harfleri</translation>
+    </message>
+    <message>
+        <location filename="../DataStream.cpp" line="324"/>
+        <source>Title</source>
+        <translation>Başlık</translation>
+    </message>
+    <message>
+        <location filename="../DataStream.cpp" line="324"/>
+        <source>Artist</source>
+        <translation>Sanatçı</translation>
+    </message>
+    <message>
+        <location filename="../DataStream.cpp" line="324"/>
+        <source>Track #</source>
+        <translation>Parça #</translation>
+    </message>
+    <message>
+        <location filename="../DataStream.cpp" line="324"/>
+        <source>Time</source>
+        <translation>Süre</translation>
+    </message>
+    <message>
+        <location filename="../DataStream.cpp" line="324"/>
+        <source>Genre</source>
+        <translation>Tür</translation>
+    </message>
+    <message>
+        <location filename="../DataStream.cpp" line="324"/>
+        <source>Picture</source>
+        <translation>Resim</translation>
+    </message>
+    <message>
+        <location filename="../DataStream.cpp" line="325"/>
+        <source>Album</source>
+        <translation>Albüm</translation>
+    </message>
+    <message>
+        <location filename="../DataStream.cpp" line="325"/>
+        <source>Rating</source>
+        <translation>Not</translation>
+    </message>
+    <message>
+        <location filename="../DataStream.cpp" line="325"/>
+        <source>Composer</source>
+        <translation>Bestekâr</translation>
+    </message>
+    <message>
+        <location filename="../DataStream.cpp" line="325"/>
+        <source>VA</source>
+        <translation>ÇS</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="511"/>
+        <location filename="../Id3V2Stream.cpp" line="548"/>
+        <source>&lt;error loading frame&gt;</source>
+        <translation>&lt;çerçevenin yüklenmesinde hata&gt;</translation>
+    </message>
+    <message>
+        <location filename="../Id3V2Stream.cpp" line="515"/>
+        <location filename="../Id3V2Stream.cpp" line="552"/>
+        <source>&lt;error decoding frame&gt;</source>
+        <translation>&lt;çerçeve kodunun açılmasında hata&gt;</translation>
+    </message>
+    <message>
+        <location filename="../LyricsStream.cpp" line="121"/>
+        <location filename="../LyricsStream.cpp" line="139"/>
+        <location filename="../LyricsStream.cpp" line="152"/>
+        <location filename="../LyricsStream.cpp" line="165"/>
+        <location filename="../LyricsStream.cpp" line="178"/>
+        <location filename="../LyricsStream.cpp" line="192"/>
+        <location filename="../LyricsStream.cpp" line="205"/>
+        <location filename="../LyricsStream.cpp" line="217"/>
+        <source>Additional %1 field: %2</source>
+        <translation>Ek %1 alanı: %2</translation>
+    </message>
+    <message>
+        <location filename="../LyricsStream.cpp" line="127"/>
+        <location filename="../LyricsStream.cpp" line="222"/>
+        <location filename="../LyricsStream.cpp" line="373"/>
+        <location filename="../LyricsStream.cpp" line="374"/>
+        <location filename="../LyricsStream.cpp" line="375"/>
+        <location filename="../LyricsStream.cpp" line="376"/>
+        <source>%1 field: %2</source>
+        <translation>%1 alanı: %2</translation>
+    </message>
+    <message>
+        <location filename="../MpegStream.cpp" line="1312"/>
+        <source>Comment: %1</source>
+        <translation>Yorum: %1</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="172"/>
+        <source>(file)</source>
+        <translation>(dosya)</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="172"/>
+        <source>(table)</source>
+        <translation>(tablo)</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.h" line="134"/>
+        <source>Pattern</source>
+        <translation>Örüntü</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.h" line="191"/>
+        <source>Web</source>
+        <translation>Web</translation>
+    </message>
+</context>
+<context>
+    <name>TagWriter</name>
+    <message>
+        <location filename="../TagWriter.cpp" line="977"/>
+        <location filename="../TagWriter.cpp" line="1675"/>
+        <location filename="../TagWriter.cpp" line="1872"/>
+        <location filename="../TagWriter.cpp" line="1958"/>
+        <location filename="../TagWriter.cpp" line="1963"/>
+        <source>Warning</source>
+        <translation>İkaz</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="977"/>
+        <source>Track numbers are supposed to be consecutive numbers from 1 to the total number of tracks. This is not the case with the current album, which may lead to incorrect assignments when pasting information.</source>
+        <translation>Parça numaralarının 1&apos;den toplam parça sayısına kadar ardışık sayılar olmaları beklenir. Bu durum mevcut albüm için geçerli değildir; bu da bilgi yapıştırılırken yanlış atamalara yol açabilir.</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="1008"/>
+        <location filename="../TagWriter.cpp" line="1665"/>
+        <location filename="../TagWriter.cpp" line="1682"/>
+        <location filename="../TagWriter.cpp" line="1945"/>
+        <location filename="../TagWriter.cpp" line="1987"/>
+        <source>Error</source>
+        <translation>Hata</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="1008"/>
+        <source>Some files have been modified by an external tool after the last scan. You won&apos;t be able to save any changes to those files until you rescan them.</source>
+        <translation>Bazı dosyalar son taramadan sonra harici bir araç tarafından değiştirilmiştir. Bu dosyalar üzerindeki herhangi bir değişikliği onları tekrar tarayana dek kaydedemezsiniz.</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="1650"/>
+        <source>Do you want to erase these files?%1</source>
+        <translation>Bu dosyaları silmek istiyor musunuz? %1</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="1655"/>
+        <source>Do you want to erase %1?</source>
+        <translation>%1 unsurunu silmek istiyor musunuz?</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="1658"/>
+        <source>Confirm</source>
+        <translation>Teyit et</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="1658"/>
+        <location filename="../TagWriter.cpp" line="1675"/>
+        <source>Erase</source>
+        <translation>Sil</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="1658"/>
+        <location filename="../TagWriter.cpp" line="1665"/>
+        <location filename="../TagWriter.cpp" line="1675"/>
+        <location filename="../TagWriter.cpp" line="1958"/>
+        <location filename="../TagWriter.cpp" line="1963"/>
+        <source>Cancel</source>
+        <translation>İptal et</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="1665"/>
+        <source>You cannot erase image files if there are unsaved values. Do you want to save?</source>
+        <translation>Kaydedilmemiş değerler mevcutsa resim dosyalarını silemezsiniz. Kaydetmek istiyor musunuz?</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="1665"/>
+        <source>Save, then erase file</source>
+        <translation>Kaydet, ardından dosyayı sil</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="1675"/>
+        <source>Erasing image files triggers a full reload, which results in downloaded and pasted data being lost. Erase anyway?</source>
+        <translation>Resim dosyalarının silinmesi tam tekrar yüklemeye yol açar, ki bu indirilmiş ve yapıştırılmış verilerin kaybolmasına sebep olur. Yine de silinsin mi?</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="1682"/>
+        <source>Couldn&apos;t erase file &quot;%1&quot;</source>
+        <translation>&quot;%1&quot; dosyası silinemedi</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="1872"/>
+        <source>Currently pasting multiple file names is not supported, so only the first one is considered.</source>
+        <translation>Güncel olarak çoklu dosya ismi yapıştırılması desteklenmemektedir, dolayısıyla sadece ilki dikkate alınır.</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="1945"/>
+        <source>The pasted value couldn&apos;t be assigned to some fields</source>
+        <translation>Yapıştırılan değer bazı alanlara atanamadı</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="1945"/>
+        <source>The pasted value couldn&apos;t be assigned to any field</source>
+        <translation>Yapıştırılan değer hiçbir alana atanamadı</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="1958"/>
+        <source>The number of lines in the clipboard is different from the number of files. Paste anyway?</source>
+        <translation>Panodaki satır sayısı dosya sayısından farklı. Yine de yapıştırılsın mı?</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="1958"/>
+        <location filename="../TagWriter.cpp" line="1963"/>
+        <source>Paste</source>
+        <translation>Yapıştır</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="1963"/>
+        <source>The track numbers aren&apos;t consecutive numbers starting at 1, so the pasted track information might not match the tracks. Paste anyway?</source>
+        <translation>Parça sayıları 1&apos;den başlayan ardışık sayılar değildir, yani yapıştırılan parça bilgileri parçalarla eşleşmeyebilir. Yine de yapıştırılsın mı?</translation>
+    </message>
+    <message>
+        <location filename="../TagWriter.cpp" line="1987"/>
+        <source>Unrecognized clipboard content</source>
+        <translation>Tanınmayan pano içeriği</translation>
+    </message>
+</context>
+<context>
+    <name>ThreadRunnerDlg</name>
+    <message>
+        <location filename="../ThreadRunner.ui" line="14"/>
+        <source>Thread Runner</source>
+        <translation>İş Parçacığı Başlatıcı</translation>
+    </message>
+    <message>
+        <location filename="../ThreadRunner.ui" line="23"/>
+        <source>TextLabel</source>
+        <translation>TextLabel</translation>
+    </message>
+    <message>
+        <location filename="../ThreadRunner.ui" line="45"/>
+        <source>&amp;Pause</source>
+        <translation>&amp;Duraklat</translation>
+    </message>
+    <message>
+        <location filename="../ThreadRunner.ui" line="52"/>
+        <source>&amp;Abort</source>
+        <translation>&amp;İptal et</translation>
+    </message>
+</context>
+<context>
+    <name>ThreadRunnerDlgImpl</name>
+    <message>
+        <location filename="../ThreadRunnerDlgImpl.cpp" line="142"/>
+        <source>Completed</source>
+        <translation>Tamamlanmış</translation>
+    </message>
+    <message>
+        <location filename="../ThreadRunnerDlgImpl.cpp" line="154"/>
+        <source>&amp;Resume</source>
+        <translation>D&amp;evam et</translation>
+    </message>
+    <message>
+        <location filename="../ThreadRunnerDlgImpl.cpp" line="161"/>
+        <source>&amp;Pause</source>
+        <translation>&amp;Duraklat</translation>
+    </message>
+    <message>
+        <location filename="../ThreadRunnerDlgImpl.cpp" line="300"/>
+        <source>
+
+Total time: %1
+Running time: %2</source>
+        <translation>
+
+Toplam süre: %1
+Çalışma süresi: %2</translation>
+    </message>
+    <message>
+        <location filename="../ThreadRunnerDlgImpl.cpp" line="305"/>
+        <source>Time: %1</source>
+        <translation>Süre: %1</translation>
+    </message>
+</context>
+<context>
+    <name>TrackTextParser</name>
+    <message>
+        <location filename="../SongInfoParser.cpp" line="837"/>
+        <source>&quot;%1&quot; is not a valid pattern. Error in column %2.</source>
+        <translation>&quot;%1&quot;, geçerli bir örüntü değildir. %2 sütununda hata.</translation>
+    </message>
+</context>
+<context>
+    <name>TransfConfig</name>
+    <message>
+        <location filename="../Transformation.cpp" line="208"/>
+        <source>Error</source>
+        <translation>Hata</translation>
+    </message>
+    <message>
+        <location filename="../Transformation.cpp" line="208"/>
+        <source>Invalid value found for file settings. Reverting to default settings.</source>
+        <translation>Dosya ayarları için geçersiz bir değer tespit edildi. Varsayılan ayarlara geri dönülüyor.</translation>
+    </message>
+</context>
+<context>
+    <name>Transformation</name>
+    <message>
+        <location filename="../Id3Transf.cpp" line="327"/>
+        <source>Convert non-ASCII ID3V2 text frames to Unicode assuming codepage %1</source>
+        <translation>ASCII olmayan ID3V2 metin çerçevelerini %1 kod sayfasını kullanarak Unikod&apos;a çevir</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.cpp" line="447"/>
+        <source>Change case for ID3V2 text frames: Artists - %1; Others - %2</source>
+        <translation>ID3V2 metin çerçeveleri için büyük/küçük harf değiştir: Sanatçılar - %1; Diğerleri - %2</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.cpp" line="742"/>
+        <source>Copy missing ID3V2 frames from ID3V1 assuming codepage %1</source>
+        <translation>Eksik ID3V2 çerçevelerini ID3V1&apos;den %1 kod sayfasını varsayarak kopyala</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="43"/>
+        <source>Removes all ID3V2 frames that aren&apos;t used by MP3 Diags. You normally don&apos;t want to do such a thing, but it may help if some other program misbehaves because of invalid or unknown frames in an ID3V2 tag.</source>
+        <translation>MP3 Diags tarafından kullanılmayan tüm ID3V2 çerçevelerini kaldırır. Normal olarak böyle bir şey yapmak istemezsiniz, fakat bir ID3V2 etiketindeki geçersiz veya bilinmeyen çerçeveler sebebiyle başka bir program doğru işlemezse bu yardımcı olabilir.</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="45"/>
+        <source>Remove non-basic ID3V2 frames</source>
+        <translation>Temel olmayan ID3V2 çerçevelerini kaldır</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="57"/>
+        <source>Copies only ID3V2 frames that seem valid or can be made valid, discarding those that are invalid and can&apos;t be fixed (e.g. an APIC frame claiming to hold a picture although it doesn&apos;t.) Handles both loadable and broken ID3V2 tags, in the latter case copying being stopped when a fatal error occurs.</source>
+        <translation>Sadece geçerli olan veya geçerli hâle getirilebilecek ID3V2 çerçevelerini kopyalar, geçersiz olanları ve tamir edilemeyecek olanları dikkate almaz (mesela resim içerdiğini beyan eden fakat resim bulundurmayan bir APIC çerçevesi.) Hem yüklenebilir hem de bozuk ID3V2 etiketlerini işler; bozuk etiketlerde ise ölümcül bir hata oluştuğunda kopyalama işlemi durdurulur.</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="59"/>
+        <source>Discard invalid ID3V2 data</source>
+        <translation>Geçersiz ID3V2 verilerini dikkate alma</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="73"/>
+        <source>Transforms text frames in ID3V2 encoded as Latin1 to Unicode (UTF16.) The reason to do this is that sometimes non-conforming software treats these frames as they are encoded in a different code page, causing other programs to display unexpected data.</source>
+        <translation>Latin1 ile kodlanmış ID3V2 metin çerçevelerini Unikod&apos;a (UTF16) dönüştürür. Bunun yapılmasının sebebi, bazen standartlara uymayan yazılımların bu çerçeveleri başka bir kod sayfasında kodlanmış gibi işlemeleri ve diğer programların beklenmeyen veri görüntülemelerine yol açmalarıdır.</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="75"/>
+        <source>Convert non-ASCII ID3V2 text frames to Unicode</source>
+        <translation>ASCII olmayan ID3V2 metin çerçevelerini Unikod&apos;a dönüştür</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="89"/>
+        <source>Transforms the case of text frames in ID3V2 tags, according to global settings.</source>
+        <translation>Genel ayarlara uygun olarak ID3V2 etiketlerindeki metin çerçevelerinin büyük/küçük harf ayarını değiştirir.</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="91"/>
+        <source>Change case for ID3V2 text frames</source>
+        <translation>ID3V2 metin çerçevelerinin büyük/küçük harf ayarını değiştir</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="107"/>
+        <source>Copies frames from ID3V1 to ID3V2 if those frames don&apos;t exist in the destination or if the destination doesn&apos;t exist at all.</source>
+        <translation>Söz konusu çerçeveler hedefte mevcut değilse veya hedefin kendisi mevcut değilse ID3V1 etiketinden ID3V2 etiketine çerçeveleri kopyalar.</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="109"/>
+        <source>Copy missing ID3V2 frames from ID3V1</source>
+        <translation>Eksik ID3V2 çerçevelerini ID3V1 etiketinden kopyala</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="120"/>
+        <source>Adds the value of the composer field to the beginning of the artist field in ID3V2 frames. Useful for players that don&apos;t use the composer field.</source>
+        <translation>ID3V2 çerçevelerinde bestekâr alanının değerini  sanatçı alanının başına ekler. Bestekâr alanını kullanmayan oynatıcılar için kullanışlıdır.</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="122"/>
+        <source>Add composer field to the artist field in ID3V2 frames</source>
+        <translation>ID3V2 çerçevelerinde bestekâr alanını sanatçı alanına ekle</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="133"/>
+        <source>&quot;Undo&quot; for &quot;adding composer field.&quot; Removes the value of the composer field from the beginning of the artist field in ID3V2 frames, if it was previously added.</source>
+        <translation>&quot;Bestekâr alanının eklenmesini&quot; &quot;geri alma&quot; işlevi. Eğer önceden eklendiyse, ID3V2 çerçevelerinde bestekâr alanının değerini sanatçı alanından kaldırır.</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="135"/>
+        <source>Remove composer field from the artist field in ID3V2 frames</source>
+        <translation>ID3V2 çerçevelerinde bestekâr alanını sanatçı alanından kaldır</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="146"/>
+        <source>Copies to the &quot;Composer&quot; field the beginning of an &quot;Artist&quot; field that is formatted as &quot;Composer [Artist]&quot;. Does nothing if the &quot;Artist&quot; field doesn&apos;t have this format.</source>
+        <translation>&quot;Bestekâr&quot; alanına &quot;Bestekâr [Sanatçı]&quot; şeklinde biçimlendirilmiş &quot;Sanatçı&quot; alanının başını kopyalar. &quot;Sanatçı&quot; alanı bu biçimde değilse hiçbir şey yapmaz.</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="148"/>
+        <source>Fill in composer field based on artist in ID3V2 frames</source>
+        <translation>ID3V2 çerçevelerinde bestekâr alanını sanatçıya dayalı olarak doldur</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="159"/>
+        <source>Keeps only the biggest (and supposedly the best) image in a file. The image type is set to Front Cover. (This may result in the replacement of the Front Cover image.)</source>
+        <translation>Dosyada sadece en büyük (ve teorik olarak en iyi) resmi muhafaza eder. Resim türü Albüm Kapağı olarak ayarlanır. (Bu, Albüm Kapağı resminin yerine koyamaya yol açabilir.)</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="161"/>
+        <source>Make the largest image &quot;Front Cover&quot; and remove the rest</source>
+        <translation>En büyük resmi &quot;Albüm Kapağı&quot; olarak ayarla ve kalanı kaldır</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="173"/>
+        <source>Adds extra spacing to the ID3V2 tag. This allows subsequent saving from the tag editor to complete quicker.</source>
+        <translation>ID3V2 etiketine ilave boşluk ekler. Bu, etiket düzenleyicideki daha sonraki kayıtların daha hızlı tamamlanmalarına imkân sağlar.</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="175"/>
+        <source>Reserve space in ID3V2 for fast tag editing</source>
+        <translation>ID3V2 etiketinde hızlı etiket düzenleme için yer ayır</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="187"/>
+        <source>Removes large unused blocks from ID3V2 tags. (Usually these have been reserved for fast tag editing, in which case they should be removed only after the ID3V2 tag has all the right values.)</source>
+        <translation>ID3V2 etiketlerinden büyük kullanılmayan blokları kaldırır. (Genelde bunlar hızlı etiket düzenlemesi için ayrılmıştır, bu durumda sadece ID3V2 etiketinin değerlerinin tümü doğru olduğunda kaldırılmalıdır.)</translation>
+    </message>
+    <message>
+        <location filename="../Id3Transf.h" line="189"/>
+        <source>Remove extra space from ID3V2</source>
+        <translation>ID3V2 etiketinden ilave boşlukları kaldır</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2675"/>
+        <source>Removes selected streams.</source>
+        <translation>Seçili akışları kaldır.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2677"/>
+        <source>Remove selected stream(s)</source>
+        <translation>Seçili akış(lar)ı kaldır</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="3025"/>
+        <source>Removes specified stream.</source>
+        <translation>Belirtilen akışı kaldırır.</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="3027"/>
+        <source>Remove specified stream</source>
+        <translation>Belirtilen akışı kaldır</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="42"/>
+        <source>Sometimes a bit gets flipped in a file. This tries to identify places having this issue in audio frame headers. If found, it fixes the problem. It is most likely to apply to files that have 2 audio streams.</source>
+        <translation>Bazen dosyada bir bitin değeri değişebilir. Bu, ses çerçeve başlıklarında bu soruna sahip yerleri tespit etmeye çalışır. Bulursa sorunu düzeltir. En çok 2 ses akışı bulunduran dosyalara uygulanması muhtemeldir.</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="44"/>
+        <source>Restore flipped bit in audio</source>
+        <translation>Sesteki değeri tersine dönmüş bitleri geri al</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="74"/>
+        <source>Removes all non-audio data that is found between audio streams. In this context, VBRI streams are considered audio streams (while Xing streams are not.)</source>
+        <translation>Ses akışları arasında bulunan tüm ses olmayan verileri kaldırır. Bu bağlamda VBRI akışları ses akışı olarak kabul edilir (ancak Xing akışları ses akışı olarak kabul edilmez.)</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="76"/>
+        <source>Remove inner non-audio</source>
+        <translation>Ses içermeyen iç kısmı kaldır</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="86"/>
+        <source>Removes all unknown streams.</source>
+        <translation>Bilinmeyen tüm akışları kaldırır.</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="88"/>
+        <source>Remove unknown streams</source>
+        <translation>Bilinmeyen akışları kaldır</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="96"/>
+        <source>Removes all broken streams.</source>
+        <translation>Tüm hasarlı akışları kaldırır.</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="98"/>
+        <source>Remove broken streams</source>
+        <translation>Hasarlı akışları kaldır</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="106"/>
+        <source>Removes all unsupported streams.</source>
+        <translation>Desteklenmeyen tüm akışları kaldırır.</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="108"/>
+        <source>Remove unsupported streams</source>
+        <translation>Desteklenmeyen tüm akışları kaldır</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="116"/>
+        <source>Removes all truncated audio streams.</source>
+        <translation>Kesik tüm ses akışlarını kaldırır.</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="118"/>
+        <source>Remove truncated audio streams</source>
+        <translation>Kesik ses akışlarını kaldır</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="126"/>
+        <source>Removes all null streams.</source>
+        <translation>Boş tüm akışları kaldırır.</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="128"/>
+        <source>Remove null streams</source>
+        <translation>Tüm boş akışları kaldır</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="139"/>
+        <source>Removes all streams that are broken, truncated, unsupported or have some errors making them unusable.</source>
+        <translation>Tüm hasarlı, kesik, desteklenmeyen veya hatalar sebebiyle kullanılamaz hâle gelmiş akışları kaldırır.</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="153"/>
+        <source>Removes broken ID3V2 streams.</source>
+        <translation>Hasarlı ID3V2 akışlarını kaldırır.</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="155"/>
+        <source>Remove broken ID3V2 streams</source>
+        <translation>Hasarlı ID3V2 akışlarını kaldır</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="164"/>
+        <source>Removes unsupported ID3V2 streams.</source>
+        <translation>Desteklenmeyen ID3V2 akışlarını kaldırır.</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="166"/>
+        <source>Remove unsupported ID3V2 streams</source>
+        <translation>Desteklenmeyen ID3V2 akışlarını kaldır</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="178"/>
+        <source>If a file has multiple ID3 streams it keeps only the last ID3V1 and the first ID3V2 stream.</source>
+        <translation>Şayet bir dosya birçok ID3 akışına sahipse, sadece son ID3V1 ve ilk ID3V2 akışlarını muhafaza eder.</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="180"/>
+        <source>Remove multiple ID3 streams</source>
+        <translation>Çoklu ID3 akışlarını kaldır</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="197"/>
+        <source>Sometimes the number of frames in an audio stream is different from the number of frames in a preceding Xing (or Lame) header, usually because the audio stream was damaged. It&apos;s probably best for the Xing header to be removed in this case. If the audio is VBR, you may want to try &quot;Repair VBR data&quot; first. (If the number of frames specified in the Xing header is the number of audio frames + 1, the header won&apos;t be removed, as this is an old bug in some encoders and players know how to deal with it.)</source>
+        <translation>Bazen bir ses akışındaki çerçeve sayısı, önceden gelen Xing (veya Lame) başlığındaki sayıdan farklıdır, genelde ses akışı hasar gördüğünden dolayı. Bu durumda muhtemelen en doğrusu Xing başlığının kaldırılmasıdır. Eğer ses VBR ise, önce &quot;VBR verileri tamir et&quot; seçeneğini denemek isteyebilirsiniz. (Şayet Xing başlığında belirtilen çerçeve sayısı ses çerçeveleri +1 ise başlık kaldırılmaz, çünkü bu, bazı kodlayıcılardaki eski bir hatadır ve oynatıcılar onun nasıl üstesinden gelineceğini bilir.)</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="199"/>
+        <source>Remove mismatched Xing headers</source>
+        <translation>Uyumsuz Xing başlıklarını kaldır</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="216"/>
+        <source>Removes Xing or LAME streams from files encoded using CBR.</source>
+        <translation>CBR kullanılarak kodlanmış dosyalardan Xing veya LAME akışlarını kaldırır.</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="218"/>
+        <source>Remove Xing or LAME streams from CBR files</source>
+        <translation>CBR dosyalardan Xing veya LAME akışlarını kaldır</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="233"/>
+        <source>Removes all ID3V1 streams.</source>
+        <translation>Tüm ID3V1 akışlarını kaldırır.</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="235"/>
+        <source>Remove all ID3V1 streams</source>
+        <translation>Tüm ID3V1 akışlarını kaldır</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="244"/>
+        <source>Removes all APE streams.</source>
+        <translation>Tüm APE akışlarını kaldırır.</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="246"/>
+        <source>Remove all APE streams</source>
+        <translation>Tüm APE akışlarını kaldır</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="255"/>
+        <source>Removes all non-audio streams.</source>
+        <translation>Tüm ses olmayan akışları kaldırır.</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="257"/>
+        <source>Remove all non-audio streams</source>
+        <translation>Ses olmayan tüm akışları kaldır</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="266"/>
+        <source>Removes all Xing streams.</source>
+        <translation>Tüm Xing akışlarını kaldırır.</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="268"/>
+        <source>Remove all Xing streams</source>
+        <translation>Tüm Xing akışlarını kaldır</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="277"/>
+        <source>Removes all LAME streams.</source>
+        <translation>Tüm LAME akışlarını kaldırır.</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="279"/>
+        <source>Remove all LAME streams</source>
+        <translation>Tüm LAME akışlarını kaldır</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="291"/>
+        <source>Pads truncated audio frames with 0 to the right. Its usefulness hasn&apos;t been determined yet (it might be quite low.)</source>
+        <translation>Kesik ses çerçevelerini sağa doğru 0&apos;lar ile dolgular. Kullanışlılığı henüz belirlenmemiştir (oldukça düşük olabilir.)</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="293"/>
+        <source>Pad truncated audio</source>
+        <translation>Kesik sesi dolgula</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="312"/>
+        <source>If a file contains VBR audio but doesn&apos;t have a Xing header, one such header is added. If a VBRI header exists, it is removed. If a Xing header exists but is determined to be incorrect, it is corrected or replaced. Only the first audio stream is considered; if a file contains more than one audio stream, this should be fixed first.</source>
+        <translation>Şayet bir dosya VBR ses içeriyorsa fakat bir Xing başlığı bulundurmuyorsa, böyle bir başlık eklenir. Eğer bir VBRI başlığı mevcutsa kaldırılır. Eğer bir Xing başlığı mevcutsa fakat yanlış olduğu tespit edildiyse, düzeltilir veya yerine yenisi konur. Sadece ilk ses akışı dikkate alınır, şayet bir dosya birden fazla ses akışına sahipse önce bunun düzeltilmesi gerekir.</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="314"/>
+        <source>Repair VBR data</source>
+        <translation>VBR verileri tamir et</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="323"/>
+        <source>If a file contains VBR audio, any existing VBRI or Xing headers are removed and a new Xing header is created. Only the first audio stream is considered; if a file contains more than one audio stream, this should be fixed first.</source>
+        <translation>Eğer bir dosya VBR sese sahipse, mevcut VBRI veya Xing başlıkları kaldırılır ve yeni bir Xing başlığı oluşturulur. Sadece ilk ses akışı dikkate alınır, şayet bir dosya birden fazla ses akışına sahipse önce bunun düzeltilmesi gerekir.</translation>
+    </message>
+    <message>
+        <location filename="../StructuralTransformation.h" line="325"/>
+        <source>Rebuild VBR data</source>
+        <translation>VBR verileri tekrar oluştur</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1477"/>
+        <source>Saves user-edited ID3V2.3.0 tags.</source>
+        <translation>Kullanıcı tarafından düzenlenilen ID3V2.3.0 etiketleri kaydeder.</translation>
+    </message>
+    <message>
+        <location filename="../TagEditorDlgImpl.cpp" line="1480"/>
+        <source>Save ID3V2.3.0 tags</source>
+        <translation>ID3V2.3.0 etiketleri kaydet</translation>
+    </message>
+    <message>
+        <location filename="../Transformation.h" line="377"/>
+        <source>Doesn&apos;t actually change the file, but it creates a temporary copy and it reports that it does change it. This is not as meaningless as it might first seem: if the configuration settings indicate some action (i.e. rename, move or erase) to be taken for processed files, then that action will be performed for these files. While the same can be achieved by changing the settings for unprocessed files, this is easier to use when it is executed on a subset of all the files (filtered or selected).</source>
+        <translation>Dosyayı hakikaten değiştirmez, fakat geçici bir kopyasını oluşturur ve değişiklikleri rapor eder. Bu, ilk göründüğü kadar anlamsız değildir: eğer yapılandırma ayarları işlenilen dosyalar için bir eyleme işaret ediyorlarsa (tekrar isimlendirme, taşıma veya silme), bu eylem bu dosyalar için tatbik edilir. Her ne kadar aynı sonuç işlenmeyen dosyalar için ayarları değiştirerek de elde edilebilse dahi, bu yöntemin kullanımı, tüm dosyaların (filtrelenmiş veya seçilmiş) bir alt kümesinde çalıştırıldığında daha kolaydır.</translation>
+    </message>
+    <message>
+        <location filename="../Transformation.h" line="379"/>
+        <source>No change</source>
+        <translation>Değişiklik yok</translation>
+    </message>
+</context>
+<context>
+    <name>UniqueNotesModel</name>
+    <message>
+        <location filename="../UniqueNotesModel.cpp" line="81"/>
+        <source>L</source>
+        <translation>L</translation>
+    </message>
+    <message>
+        <location filename="../UniqueNotesModel.cpp" line="82"/>
+        <source>Note</source>
+        <translation>Not</translation>
+    </message>
+</context>
+<context>
+    <name>VisibleTransfPainter</name>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="147"/>
+        <source>Action</source>
+        <translation>Eylem</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="147"/>
+        <source>Description</source>
+        <translation>Tanımlama</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="191"/>
+        <source>Add selected transformation(s)</source>
+        <translation>Seçili dönüştürmeleri ekle</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="192"/>
+        <source>Remove selected transformation(s)</source>
+        <translation>Seçili dönüştürmeleri kaldır</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="195"/>
+        <source>Restore current list to its default value</source>
+        <translation>Güncel listeyi varsayılan değerine geri getir</translation>
+    </message>
+    <message>
+        <location filename="../ConfigDlgImpl.cpp" line="196"/>
+        <source>Restore current list to the configuration it had when the window was open</source>
+        <translation>Güncel listeyi pencere açıkken sahip olduğu yapılandırmaya geri getir</translation>
+    </message>
+</context>
+<context>
+    <name>WebDwnldModel</name>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="1167"/>
+        <source>Pos</source>
+        <translation>Konum</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="1167"/>
+        <source>Title</source>
+        <translation>Başlık</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="1167"/>
+        <source>Artist</source>
+        <translation>Sanatçı</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="1167"/>
+        <source>Composer</source>
+        <translation>Bestekâr</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="1167"/>
+        <source>Volume</source>
+        <translation>Ses düzeyi</translation>
+    </message>
+</context>
+</TS>

--- a/src/translations/mp3diags_tr_TR.ts
+++ b/src/translations/mp3diags_tr_TR.ts
@@ -491,10 +491,6 @@ Hata: %1</translation>
         <translation>sonuç alındı</translation>
     </message>
     <message>
-        <source>Couldn&apos;t process the search result. (Usually this means that the server is busy, so trying later might work.)</source>
-        <translation type="vanished">Arama sonucu işlenemedi. (Bu, genelde sunucunun meşgul olduğu anlamına gelir yani daha sonra tekrar denemek işe yarayabilir.)</translation>
-    </message>
-    <message>
         <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="810"/>
         <source>No results found</source>
         <translation>Hiçbir sonuç bulunamadı</translation>
@@ -502,11 +498,7 @@ Hata: %1</translation>
     <message>
         <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="820"/>
         <source>album info received</source>
-        <translation>albüm bilgisi alındı</translation>
-    </message>
-    <message>
-        <source>Couldn&apos;t process the album information. (Usually this means that the server is busy, so trying later might work.)</source>
-        <translation type="vanished">Albüm bilgileri işlenemedi. (Bu, genelde sunucunun meşgul olduğu manasına gelir yani daha sonra tekrar denemek işe yarayabilir.)</translation>
+        <translation>albüm bilgileri alındı</translation>
     </message>
     <message>
         <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="843"/>
@@ -642,7 +634,6 @@ Hata: %1</translation>
         <location filename="../Config.ui" line="1145"/>
         <location filename="../Config.ui" line="1239"/>
         <source>...</source>
-        <translatorcomment>...</translatorcomment>
         <translation>...</translation>
     </message>
     <message>
@@ -1569,34 +1560,6 @@ Altı çizili bir yazı tipi, boşlukların görünmesine izin vermek için kull
         <translation>Tek kanal</translation>
     </message>
     <message>
-        <source>Not an MPEG frame. Synch missing.</source>
-        <translation type="vanished">Bir MPEG çerçevesi değil. Eşleşme eksik.</translation>
-    </message>
-    <message>
-        <source>Not an MPEG frame. Unsupported version (2.5).</source>
-        <translation type="vanished">Bir MPEG çerçevesi değil. Desteklenmeyen sürüm (2.5).</translation>
-    </message>
-    <message>
-        <source>Not an MPEG frame. Invalid version.</source>
-        <translation type="vanished">Bir MPEG çerçevesi değil. Geçersiz sürüm.</translation>
-    </message>
-    <message>
-        <source>Not an MPEG frame. Invalid layer.</source>
-        <translation type="vanished">Bir MPEG çerçevesi değil. Geçersiz katman (layer).</translation>
-    </message>
-    <message>
-        <source>Not an MPEG frame. Invalid bitrate.</source>
-        <translation type="vanished">Bir MPEG çerçevesi değil. Geçersiz hız.</translation>
-    </message>
-    <message>
-        <source>Not an MPEG frame. Invalid frequency for MPEG1.</source>
-        <translation type="vanished">Bir MPEG çerçevesi değil. MPEG1 için geçersiz frekans.</translation>
-    </message>
-    <message>
-        <source>Not an MPEG frame. Invalid frequency for MPEG2.</source>
-        <translation type="vanished">Bir MPEG çerçevesi değil. MPEG2 için geçersiz frekans.</translation>
-    </message>
-    <message>
         <location filename="../Helpers.cpp" line="372"/>
         <source>%1 %2%3%4%5%6Hz%7%8bps%9CRC=%10%11length %12 (0x%13)%14padding=%15</source>
         <translation>%1 %2%3%4%5%6Hz%7%8bps%9CRC=%10%11süre %12 (0x%13)%14dolgu=%15</translation>
@@ -1777,8 +1740,7 @@ listesinde görüntülenir.
 Şıkkın işaretli olmadığı zaman izleme notlarının dosya
 analizi esnasında dikkate alınmayacaklarını, yani bu şıkkı
 sonradan işaretlerseniz bunun onları görüntülemeyeceğini
-unutmayın.
-Yeni bir analiz gerekecektir.</translation>
+unutmayın. Götüntülenmeleri için yeni bir analiz gerekecektir.</translation>
     </message>
     <message>
         <location filename="../DebugDlgImpl.cpp" line="150"/>
@@ -1817,6 +1779,11 @@ Yeni bir analiz gerekecektir.</translation>
 <context>
     <name>DirFilterDlgImpl</name>
     <message>
+        <location filename="../DirFilterDlgImpl.cpp" line="92"/>
+        <source>Folder</source>
+        <translation>Dizin</translation>
+    </message>
+    <message>
         <location filename="../DirFilterDlgImpl.cpp" line="198"/>
         <source>&lt;all folders&gt;</source>
         <translation>&lt;tüm dizinler&gt;</translation>
@@ -1845,11 +1812,6 @@ Yeni bir analiz gerekecektir.</translation>
         <location filename="../DirFilterDlgImpl.cpp" line="305"/>
         <source>Restore lists to the configuration they had when the window was open</source>
         <translation>Listeleri pencere açıkken mevcut olan yapılandırmaya geri al</translation>
-    </message>
-    <message>
-        <location filename="../DirFilterDlgImpl.cpp" line="92"/>
-        <source>Folder</source>
-        <translation>Dizin</translation>
     </message>
 </context>
 <context>
@@ -2094,6 +2056,7 @@ Bu, göreli yollar içeren M3U dosyaları oluşturmak için faydalıdır.</trans
         <location filename="../ExportDlgImpl.cpp" line="325"/>
         <source>EWST</source>
         <comment>the letters are the initials of the 4 severity levels: Error, Warning, Support, Trace</comment>
+        <translatorcomment>Hata, Uyarı, Destek, İz</translatorcomment>
         <translation>HUDİ</translation>
     </message>
     <message>
@@ -2542,10 +2505,6 @@ Bu, göreli yollar içeren M3U dosyaları oluşturmak için faydalıdır.</trans
         <location filename="../Id3V230Stream.cpp" line="109"/>
         <source>Truncated ID3V2.3.0 tag.</source>
         <translation>Kesik ID3V2.3.0 etiketi.</translation>
-    </message>
-    <message>
-        <source>Broken ID3V2.3.0 tag.</source>
-        <translation type="vanished">Hasarlı ID3V2.3.0 etiketi.</translation>
     </message>
     <message>
         <location filename="../Id3V230Stream.cpp" line="78"/>
@@ -3146,12 +3105,13 @@ Bu, göreli yollar içeren M3U dosyaları oluşturmak için faydalıdır.</trans
         <translation>&quot;Dikkate alınmayan notlar&quot; listesi ayarlamasında hata</translation>
     </message>
     <message>
+        <location filename="../MainFormDlgImpl.cpp" line="649"/>
         <source>
 
 You may want to check again the list and add any notes that you want to ignore.
 
-(If you didn&apos;t change the settings file manually, this is probably due to a code enhanement that makes some notes no longer needed, and you can safely ignore this message.)</source>
-        <translation type="vanished">
+If you didn&apos;t change the settings file manually, this is probably due to a code enhancement that makes some notes no longer needed, and you can safely ignore this message.)</source>
+        <translation>
 
 Listeyi tekrar kontrol edip görmezden gelmek istediğiniz notları ekleyebilirsiniz.
 
@@ -3288,6 +3248,26 @@ Listeyi tekrar kontrol edip görmezden gelmek istediğiniz notları ekleyebilirs
         <translation>MP3 dosyaları taranıyor</translation>
     </message>
     <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1755"/>
+        <source>Issues encountered while scanning the requested folders</source>
+        <translation>Des problèmes ont été rencontrés en scannant les dossiers demandés</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="1755"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2334"/>
+        <source>&lt;p&gt;Rebuilding VBR data in Xing / LAME headers can destroy gapless playing information, causing albums that are supposed to be gapless to be played with short gaps between tracks.&lt;/p&gt;&lt;p&gt;Note that this shouldn&apos;t matter for regular, non-gapless, albums.&lt;/p&gt;&lt;p&gt;Proceed?&lt;/p&gt;</source>
+        <translation>&lt;p&gt;VBR verilerini Xing / LAME başlıklarında tekrar oluşturmak aralıksız çalma bilgilerini imha edebilir, ki bu aralıksız çalınması beklenen albümlerin parçalar arasında kısa aralıklarla çalınmalarına sebep olabilir.&lt;/p&gt;&lt;p&gt;Bunun olağan, aralıksız olmayan albümler için bir sorun teşkil etmeyeceğini unutmayın.&lt;/p&gt;&lt;p&gt;Devam edilsin mi?&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../MainFormDlgImpl.cpp" line="2356"/>
+        <source>&lt;p&gt;Removing Xing / LAME headers destroys gapless playing information, causing albums that are supposed to be gapless to be played with short gaps between tracks.&lt;/p&gt;&lt;p&gt;Note that this shouldn&apos;t matter for regular, non-gapless, albums.&lt;/p&gt;&lt;p&gt;Proceed?&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Xing / LAME başlıklarının kaldırılmaları aralıksız çalma bilgilerini imha eder, ki bu aralıksız çalınması beklenen albümlerin parçalar arasında kısa aralıklarla çalınmalarına sebep olabilir.&lt;/p&gt;&lt;p&gt;Bunun olağan, aralıksız olmayan albümler için bir sorun teşkil etmeyeceğini unutmayın.&lt;/p&gt;&lt;p&gt;Devam edilsin mi?&lt;/p&gt;</translation>
+    </message>
+    <message>
         <location filename="../MainFormDlgImpl.cpp" line="2840"/>
         <location filename="../MainFormDlgImpl.cpp" line="2967"/>
         <source>Info</source>
@@ -3301,29 +3281,6 @@ Listeyi tekrar kontrol edip görmezden gelmek istediğiniz notları ekleyebilirs
         <translation>MP3 bilgilerinin yüklenmeleri esnasında bir hata meydana geldi. Dosyalarınız tekrar taranacaktır.
 
 %1</translation>
-    </message>
-    <message>
-        <location filename="../MainFormDlgImpl.cpp" line="649"/>
-        <source>
-
-You may want to check again the list and add any notes that you want to ignore.
-
-(If you didn&apos;t change the settings file manually, this is probably due to a code enhancement that makes some notes no longer needed, and you can safely ignore this message.)</source>
-        <translation>
-
-Listeyi tekrasr kontrol etmek ve dikkate almamak istediğiniz notları eklemek isteyebilirsiniz.
-
-(Eğer yapılandırma dosyasını el ile değiştirmediyseniz bu, muhtemelen bazı notları artık fuzuli kılan bir kod iyileştirmesinden kaynaklanmaktadır ve bu mesajı güvenle görmezden gelebilirsiniz.)</translation>
-    </message>
-    <message>
-        <location filename="../MainFormDlgImpl.cpp" line="1755"/>
-        <source>Issues encountered while scanning the requested folders</source>
-        <translation>İstenen dizinlerin taranması esnasında sorunlarla karşılaşıldı</translation>
-    </message>
-    <message>
-        <location filename="../MainFormDlgImpl.cpp" line="1755"/>
-        <source>OK</source>
-        <translation>Tamam</translation>
     </message>
     <message>
         <location filename="../MainFormDlgImpl.cpp" line="1931"/>
@@ -3452,7 +3409,7 @@ Exiting ...</source>
         <source>No file is selected, therefore no transformations can be applied.
 
 Exiting ...</source>
-        <translation>Hiçbir dosya seçilmiş, dolayısıyla hiçbir dönüştürme uygulanamaz.
+        <translation>Hiçbir dosya seçilmemiş, dolayısıyla hiçbir dönüştürme uygulanamaz.
 
 Çıkılıyor ...</translation>
     </message>
@@ -3465,16 +3422,6 @@ Exiting ...</source>
         <location filename="../MainFormDlgImpl.cpp" line="2309"/>
         <source>and the other %1 selected files</source>
         <translation>ve seçili diğer %1 dosya</translation>
-    </message>
-    <message>
-        <location filename="../MainFormDlgImpl.cpp" line="2334"/>
-        <source>&lt;p&gt;Rebuilding VBR data in Xing / LAME headers can destroy gapless playing information, causing albums that are supposed to be gapless to be played with short gaps between tracks.&lt;/p&gt;&lt;p&gt;Note that this shouldn&apos;t matter for regular, non-gapless, albums.&lt;/p&gt;&lt;p&gt;Proceed?&lt;/p&gt;</source>
-        <translation>&lt;p&gt;VBR verilerini Xing / LAME başlıklarında tekrar oluşturmak aralıksız çalma bilgilerini imha edebilir, ki bu aralıksız çalınması beklenen albümlerin parçalar arasında kısa aralıklarla çalınmalarına sebep olabilir.&lt;/p&gt;&lt;p&gt;Bunun olağan, aralıksız olmayan albümler için bir sorun teşkil etmeyeceğini unutmayın.&lt;/p&gt;&lt;p&gt;Devam edilsin mi?&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <location filename="../MainFormDlgImpl.cpp" line="2356"/>
-        <source>&lt;p&gt;Removing Xing / LAME headers destroys gapless playing information, causing albums that are supposed to be gapless to be played with short gaps between tracks.&lt;/p&gt;&lt;p&gt;Note that this shouldn&apos;t matter for regular, non-gapless, albums.&lt;/p&gt;&lt;p&gt;Proceed?&lt;/p&gt;</source>
-        <translation>&lt;p&gt;Xing / LAME başlıklarının kaldırılmaları aralıksız çalma bilgilerini imha eder, ki bu aralıksız çalınması beklenen albümlerin parçalar arasında kısa aralıklarla çalınmalarına sebep olabilir.&lt;/p&gt;&lt;p&gt;Bunun olağan, aralıksız olmayan albümler için bir sorun teşkil etmeyeceğini unutmayın.&lt;/p&gt;&lt;p&gt;Devam edilsin mi?&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../MainFormDlgImpl.cpp" line="2376"/>
@@ -3872,10 +3819,6 @@ Processing aborted.</source>
         <location filename="../MusicBrainzDownloader.cpp" line="746"/>
         <source>&lt;a href=&quot;%1&quot;&gt;view at %2&lt;/a&gt;</source>
         <translation>&lt;a href=&quot;%1&quot;&gt;%2 konumunda görüntüleyin&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;a href=&quot;%1&quot;&gt;view at amazon.com&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a href=&quot;%1&quot;&gt;amazon.com konumunda görüntüle&lt;/a&gt;</translation>
     </message>
 </context>
 <context>
@@ -4378,7 +4321,7 @@ Processing aborted.</source>
     <message>
         <location filename="../Notes.h" line="319"/>
         <source>Invalid Ape tag. Header expected but footer found.</source>
-        <translation>Geçersiz Ape etiketi.Başlık bekleniyordu ancak altbilgi bulundu.</translation>
+        <translation>Geçersiz Ape etiketi. Başlık bekleniyordu ancak altbilgi bulundu.</translation>
     </message>
     <message>
         <location filename="../Notes.h" line="320"/>
@@ -4543,458 +4486,6 @@ Processing aborted.</source>
         <location filename="../Notes.cpp" line="42"/>
         <source>&lt;Placeholder for a note that can no longer be found, most likely as a result of a software upgrade. You should rescan the file.&gt;</source>
         <translation>&lt;Büyük ihtimalle yazılım güncellemesinin bir sonucu olarak bulunamayan bir not için yer tutucu. Dosyayı tekrar taramanız tavsiye edilir.&gt;</translation>
-    </message>
-    <message>
-        <source>ERROR</source>
-        <translation type="vanished">HATA</translation>
-    </message>
-    <message>
-        <source>WARNING</source>
-        <translation type="vanished">İKAZ</translation>
-    </message>
-    <message>
-        <source>SUPPORT</source>
-        <translation type="vanished">DESTEK</translation>
-    </message>
-    <message>
-        <source>Two MPEG audio streams found, but a file should have exactly one.</source>
-        <translation type="vanished">İki MPEG akışı tespit edildi, ancak bir dosya tam olarak tek bir akışa sahip olabilir.</translation>
-    </message>
-    <message>
-        <source>Low quality MPEG audio stream. (What is considered &quot;low quality&quot; can be changed in the configuration dialog, under &quot;Quality thresholds&quot;.)</source>
-        <translation type="vanished">Düşük kaliteli MPEG akışı (&quot;düşük kalite&quot; olarak neyin kabul edileceği yapılandırmadaki &quot;Kalite eşikleri&quot; sekmesinde değiştirilebilir.)</translation>
-    </message>
-    <message>
-        <source>No MPEG audio stream found.</source>
-        <translation type="vanished">Hiçbir MPEG ses akışı bulunamadı.</translation>
-    </message>
-    <message>
-        <source>VBR with audio streams other than MPEG1 Layer III might work incorrectly.</source>
-        <translation type="vanished">MPEG1 Layer III dışındaki VBR ses akışları yanlış çalışabilir.</translation>
-    </message>
-    <message>
-        <source>Incomplete MPEG frame at the end of an MPEG stream.</source>
-        <translation type="vanished">MPEG akışının sonunda tamamlanmamış bir MPEG çerçevesi.</translation>
-    </message>
-    <message>
-        <source>Valid frame with a different version found after an MPEG stream.</source>
-        <translation type="vanished">Bir MPEG akışından sonra başka sürümlü, geçerli bir çerçeve bulundu.</translation>
-    </message>
-    <message>
-        <source>Valid frame with a different layer found after an MPEG stream.</source>
-        <translation type="vanished">Bir MPEG akışından sonra geçerli ama değişik bir layer (katmanlı) çerçeve bulundu.</translation>
-    </message>
-    <message>
-        <source>Valid frame with a different channel mode found after an MPEG stream.</source>
-        <translation type="vanished">Bir MPEG akışından sonra geçerli ama farklı bir kanal kipinde çerçeve bulundu.</translation>
-    </message>
-    <message>
-        <source>Valid frame with a different frequency found after an MPEG stream.</source>
-        <translation type="vanished">Bir MPEG akışından sonra geçerli ama farklı bir frekansı olan bir çerçeve bulundu.</translation>
-    </message>
-    <message>
-        <source>Valid frame with a different CRC policy found after an MPEG stream.</source>
-        <translation type="vanished">Bir MPEG akışından sonra geçerli ama farklı bir CRC politikası olan bir çerçeve bulundu.</translation>
-    </message>
-    <message>
-        <source>Invalid MPEG stream. Stream has fewer than 10 frames.</source>
-        <translation type="vanished">Geçersiz MPEG akışı. Akış, 10&apos;dan az çerçeve barındırmaktadır.</translation>
-    </message>
-    <message>
-        <source>Invalid MPEG stream. First frame has different bitrate than the rest.</source>
-        <translation type="vanished">Geçersiz MPEG akışı. İlk çerçevenin bir hızı diğerlerinden farklıdır.</translation>
-    </message>
-    <message>
-        <source>No normalization undo information found. The song is probably not normalized by MP3Gain or a similar program. As a result, it may sound too loud or too quiet when compared to songs from other albums.</source>
-        <translation type="vanished">Normalleştirmeyi geri almak için hiçbir veri bulunamadı. Şarkı, muhtemelen MP3Gain veya benzer bir program tarafından normalleştirilmemiştir. Bunun sonucu olarak, diğer albümlerin şarkılarıyla karşılaştırıldığında sesi çok yüksek veya çok düşük olabilir.</translation>
-    </message>
-    <message>
-        <source>Found audio stream in an encoding other than &quot;MPEG-1 Layer 3&quot; or &quot;MPEG-2 Layer 3.&quot; While MP3 Diags understands such streams, very few tests were run on files containing them (because they are not supposed to be found inside files with the &quot;.mp3&quot; extension), so there is a bigger chance of something going wrong while processing them.</source>
-        <translation type="vanished">&quot;MPEG 1 Layer 3&quot; veya &quot;MPEG 2 Layer 3&quot; kodlamasından farklı kodlamalı bir ses akışı bulundu. MP3 Diags böyle akışları anlasa dahi, bunları içeren dosyalar ile çok az deneme yapılmıştır (çünkü &quot;.mp3&quot; uzantısını kullanan dosyalar içinde bulunmaları beklenmez), yani onları işlerken bir şeylerin yolunda gitmemesi ihtimali daha yüksektir.</translation>
-    </message>
-    <message>
-        <source>Two Lame headers found, but a file should have at most one of them.</source>
-        <translation type="vanished">İki Lame başlığı bulundu, ancak bir dosyanın bunlardan sadece bir başlık bulundurması beklenir.</translation>
-    </message>
-    <message>
-        <source>Xing header seems added by Mp3Fixer, which makes the first frame unusable and causes a 16-byte unknown or null stream to be detected next.</source>
-        <translation type="vanished">Xing başlığı Mp3Fixer tarafından eklenmiş gibi görünüyor, bu program ilk çerçeveyi kullanılamaz hâle getirir ve ardından 16 baytlık bilinmeyen veya boş bir akışın bulunmasına sebep olur.</translation>
-    </message>
-    <message>
-        <source>Frame count mismatch between the Xing header and the audio stream.</source>
-        <translation type="vanished">Xing başlığı ile ses akışı arasında çerçeve sayısı uyuşmazlığı.</translation>
-    </message>
-    <message>
-        <source>Two Xing headers found, but a file should have at most one of them.</source>
-        <translation type="vanished">İki Xing başlığı tespit edildi, ancak her bir dosyanın sadece tek böyle başlığı bulunmalıdır.</translation>
-    </message>
-    <message>
-        <source>The Xing header should be located immediately before the MPEG audio stream.</source>
-        <translation type="vanished">Xing başlığının ses akışından hemen sonra konumlanması gerekir.</translation>
-    </message>
-    <message>
-        <source>The Xing header should be compatible with the MPEG audio stream, meaning that their MPEG version, layer and frequency must be equal.</source>
-        <translation type="vanished">Xing başlığı ile MPEG ses akışının uyumlu olması gerekir, yani MPEG sürümü, katmanı ve frekansının eşit olmaları gereklidir.</translation>
-    </message>
-    <message>
-        <source>The MPEG audio stream uses VBR but a Xing header wasn&apos;t found. This will confuse some players, which won&apos;t be able to display the song duration or to seek.</source>
-        <translation type="vanished">MPEG ses akışı VBR kullanıyor fakat hiçbir Xing başlığı bulunamadı. Bu, bazı oynatıcıları şaşırtabilir ve bunlar şarkı süresini görüntülemeyebilir veya arama yapamayabilirler.</translation>
-    </message>
-    <message>
-        <source>Xing header included in audio frame count. This is probably best ignored, as most players are fine with it and the fix erases potentially important information, like gapless playing information or the table of contents.</source>
-        <translation type="vanished">Xing başlığı ses çerçeve sayısına dahil edilmiş. En iyisi muhtemelen bunu görmezden gelmektir, çünkü oynatıcıların çoğunluğu için sorun yaratmaz ve düzeltme potansiyel olarak arasız çalma bilgileri veya içerik tablosu gibi önemli bilgileri silebilir.</translation>
-    </message>
-    <message>
-        <source>Two VBRI headers found, but a file should have at most one of them.</source>
-        <translation type="vanished">İki VBRI başlığı bulundu, ancak her bir dosyanın en çok bir başlık bulundurması gerekir.</translation>
-    </message>
-    <message>
-        <source>VBRI headers aren&apos;t well supported by some players. They should be replaced by Xing headers.</source>
-        <translation type="vanished">VBRI başlıkları bazı oynatıcılar tarafından iyi desteklenmezler. Bunların yerine Xing başlıkları konulması tercih edilmelidir.</translation>
-    </message>
-    <message>
-        <source>VBRI header found alongside Xing header. The VBRI header should probably be removed.</source>
-        <translation type="vanished">VBRI ve Xing başlıkları tespit edildi. Muhtemelen VBRI başlığını kaldırmak gereklidir.</translation>
-    </message>
-    <message>
-        <source>Invalid ID3V2 frame. File too short.</source>
-        <translation type="vanished">Geçersiz ID3V2 çerçevesi. Dosya çok kısa.</translation>
-    </message>
-    <message>
-        <source>Invalid frame name in ID3V2 tag.</source>
-        <translation type="vanished">ID3V2 etiketindeki çerçeve ismi geçersiz.</translation>
-    </message>
-    <message>
-        <source>Flags in the first flag group that are supposed to always be 0 are set to 1. They will be ignored.</source>
-        <translation type="vanished">Daima 0 değerinde olmaları beklenen ilk bayrak grubundaki bayraklar 1 değerine ayarlanmışlardır. Dikkate alınmayacaklar.</translation>
-    </message>
-    <message>
-        <source>Flags in the second flag group that are supposed to always be 0 are set to 1. They will be ignored.</source>
-        <translation type="vanished">Daima 0 değerinde olmaları beklenen ikinci bayrak grubundaki bayraklar 1 değerine ayarlanmışlardır. Dikkate alınmayacaklar.</translation>
-    </message>
-    <message>
-        <source>Error decoding the value of a text frame while reading an Id3V2 Stream.</source>
-        <translation type="vanished">ID3V2 akışı okunurken bir metin çerçevesinin kodlamasını açma esnasında hata.</translation>
-    </message>
-    <message>
-        <source>ID3V2 tag has text frames using Latin-1 encoding that contain characters with a code above 127. While this is valid, those frames may have their content set or displayed incorrectly by software that uses the local code page instead of Latin-1. Conversion to Unicode (UTF16) is recommended.</source>
-        <translation type="vanished">ID3V2 etiketi, 127&apos;den yüksek kod içeren Latin 1 kodlaması ile metin çerçeveleri bulundurmaktadır. Her ne kadar bu geçerli olsa dahi, bu çerçevelerin içeriği Latin 1 yerine yerel kod sayfası kullanan yazılımlar tarafından yanlış ayarlanabilir veya görüntülenebilir. Unikod&apos;a (UTF16) dönüştürme tavsiye edilir.</translation>
-    </message>
-    <message>
-        <source>Empty genre frame (TCON) found.</source>
-        <translation type="vanished">Boş tür çerçevesi (TCON) tespit edildi.</translation>
-    </message>
-    <message>
-        <source>Multiple frame instances found, but only the first one will be used.</source>
-        <translation type="vanished">Birçok çerçeve örneklemesi tespit edildi, fakat sadece ilki kullanılacaktır.</translation>
-    </message>
-    <message>
-        <source>The padding in the ID3V2 tag is too large, wasting space. (Large padding improves the tag editor saving speed, if fast saving is enabled, so you may want to delay compacting the tag until after you&apos;re done with the tag editor.)</source>
-        <translation type="vanished">ID3V2 etiketindeki dolgu çok büyük, bu da yer israfına yol açıyor. (Eğer hızlı kayıt etkinleştirildiyse büyük dolgular etiket düzenleyici kayıt sürelerini iyileştirir, dolayısıyla dolguyu sıkıştırmayı etiket düzenleyiciyle işiniz bitene kadar ertelemeyi tercih edebilirsiniz.)</translation>
-    </message>
-    <message>
-        <source>Unsupported ID3V2 version.</source>
-        <translation type="vanished">Desteklenmeyen ID3V2 sürümü.</translation>
-    </message>
-    <message>
-        <source>Unsupported ID3V2 tag. Unsupported flag.</source>
-        <translation type="vanished">Desteklenmeyen ID3V2 etiketi. Desteklenmeyen bayrak.</translation>
-    </message>
-    <message>
-        <source>Unsupported value for Flags1 in ID3V2 frame. (This may also indicate that the file contains garbage where it was supposed to be zero.)</source>
-        <translation type="vanished">ID3V2 çerçevesinde desteklenmeyen Flags1 değeri. (Bu, aynı zamanda sıfır olması gereken yerlerde yanlış veriler içerdiği anlamına gelebilir.)</translation>
-    </message>
-    <message>
-        <source>Unsupported value for Flags2 in ID3V2 frame. (This may also indicate that the file contains garbage where it was supposed to be zero.)</source>
-        <translation type="vanished">ID3V2 çerçevesinde desteklenmeyen Flags2 değeri. (Bu, aynı zamanda sıfır olması gereken yerlerde yanlış veriler içerdiği anlamına gelebilir.)</translation>
-    </message>
-    <message>
-        <source>Multiple instances of the POPM frame found in ID3V2 tag. The current version discards all the instances except the first when processing this tag.</source>
-        <translation type="vanished">ID3V2 etiketinde POPM çerçevesinin birçok örneklemesi tespit edildi. Güncel sürüm bu etiketi işlerken ilk örnekleme dışındakileri kaldıracaktır.</translation>
-    </message>
-    <message>
-        <source>ID3V2 tag contains no frames, which is invalid. This note will disappear once you add track information in the tag editor.</source>
-        <translation type="vanished">ID3V2 etiketi hiçbir çerçeve içermemektedir, ki bu geçersizdir. Bu not, etiket düzenleyicide parça bilgisi eklediğinizde kalkacaktır.</translation>
-    </message>
-    <message>
-        <source>ID3V2 tag contains an empty text frame, which is invalid.</source>
-        <translation type="vanished">ID3V2 etiketi boş bir metin çerçevesi içermektedir, ki bu geçersizdir.</translation>
-    </message>
-    <message>
-        <source>ID3V2 tag doesn&apos;t have an APIC frame (which is used to store images).</source>
-        <translation type="vanished">ID3V2 etiketi APIC çerçevesi içermemektedir (resim saklamak için kullanılır).</translation>
-    </message>
-    <message>
-        <source>ID3V2 tag has an APIC frame (which is used to store images), but the image couldn&apos;t be loaded.</source>
-        <translation type="vanished">ID3V2 etiketi bir APIC çerçevesi içermektedir (resim saklamak için kullanılır), fakat resim yüklenemedi.</translation>
-    </message>
-    <message>
-        <source>ID3V2 tag has at least one valid APIC frame (which is used to store images), but no frame has a type that is associated with an album cover.</source>
-        <translation type="vanished">ID3V2 etiketi en az geçerli bir APIC çerçevesi bulundurmaktadır (resim saklamak için kullanılır), fakat hiçbir çerçevenin türü bir albüm kapağı ile ilişkili değildir.</translation>
-    </message>
-    <message>
-        <source>Error loading image in APIC frame.</source>
-        <translation type="vanished">APIC çerçevesindeki resmin yüklenmesinde hata.</translation>
-    </message>
-    <message>
-        <source>Error loading image in APIC frame. The frame is too short anyway to have space for an image.</source>
-        <translation type="vanished">APIC çerçevesindeki resmin yüklenmesinde hata. Zaten bu çerçeve bir resim içermek için çok küçük.</translation>
-    </message>
-    <message>
-        <source>ID3V2 tag has multiple APIC frames with the same picture type.</source>
-        <translation type="vanished">ID3V2 etiketi, aynı resim türü içeren birden fazla APIC çerçevesi bulunduruyor.</translation>
-    </message>
-    <message>
-        <source>ID3V2 tag has multiple APIC frames. While this is valid, players usually use only one of them to display an image, discarding the others.</source>
-        <translation type="vanished">ID3V2 etiketi birden fazla APIC çerçevesine sahiptir. Bu geçerlidir ancak oynatıcılar genelde resim görüntülemek için sadece bir tanesini kullanıp diğerlerini dikkate almazlar.</translation>
-    </message>
-    <message>
-        <source>Unsupported text encoding for APIC frame in ID3V2 tag.</source>
-        <translation type="vanished">ID3V2 etiketi içinde APIC çerçevesi için desteklenmeyen metin kodlaması.</translation>
-    </message>
-    <message>
-        <source>APIC frame uses a link to a file as a MIME Type, which is not supported.</source>
-        <translation type="vanished">APIC çerçevesi, MIME Tipi olarak bir dosyaya bağlantı kullanmaktadır, ki bu desteklenmemektedir.</translation>
-    </message>
-    <message>
-        <source>Picture description is ignored in the current version.</source>
-        <translation type="vanished">Güncel sürümde resimlerin tanımlamaları dikkate alınmaz.</translation>
-    </message>
-    <message>
-        <source>No ID3V2.3.0 tag found, although this is the most popular tag for storing song information.</source>
-        <translation type="vanished">Hiçbir ID3V2.3.0 etiketi tespit edilemedi, halbuki bu, parçalara dair bilgi saklamak için en popüler etikettir.</translation>
-    </message>
-    <message>
-        <source>Two ID3V2.3.0 tags found, but a file should have at most one of them.</source>
-        <translation type="vanished">İki ID3V2.3.0 etiketi tespit edildi, ancak bir dosyanın bunlardan en çok bir etikete sahip olması gerekir.</translation>
-    </message>
-    <message>
-        <source>Both ID3V2.3.0 and ID3V2.4.0 tags found, but there should be only one of them.</source>
-        <translation type="vanished">Hem ID3V2.3.0 hem de ID3V2.4.0 etiketleri tespit edildi, ancak ikisinden sadece birisinin mevcut olması gerekir.</translation>
-    </message>
-    <message>
-        <source>The ID3V2.3.0 tag should be the first tag in a file.</source>
-        <translation type="vanished">ID3V2.3.0 etiketi dosyanın ilk etiketi olmalıdır.</translation>
-    </message>
-    <message>
-        <source>ID3V2.3.0 tag contains a text frame encoded as UTF-8, which is valid in ID3V2.4.0 but not in ID3V2.3.0.</source>
-        <translation type="vanished">ID3V2.3.0 etiketi UTF-8 ile kodlanmış metin çerçevesi içermektedir, bu ID3V2.4.0 için geçerlidir fakat ID3V2.3.0 için geçersizdir.</translation>
-    </message>
-    <message>
-        <source>Unsupported value of text frame while reading an Id3V2 Stream.</source>
-        <translation type="vanished">ID3V2 akışı okunurken desteklenmeyen metin çerçevesi değeri.</translation>
-    </message>
-    <message>
-        <source>Invalid ID3V2.3.0 frame. Incorrect frame size or file too short.</source>
-        <translation type="vanished">Geçersiz ID3V2.3.0 çerçevesi. Yanlış çerçeve boyutu veya çok küçük dosya boyutu.</translation>
-    </message>
-    <message>
-        <source>Two ID3V2.4.0 tags found, but a file should have at most one of them.</source>
-        <translation type="vanished">İki ID3V2.4.0 etiketi tespit edildi, ancak bir dosyanın böyle en çok bir etikete sahip olması beklenir..</translation>
-    </message>
-    <message>
-        <source>Invalid ID3V2.4.0 frame. Incorrect frame size or file too short.</source>
-        <translation type="vanished">Geçersiz ID3V2.4.0 çerçevesi. Yanlış çerçeve boyutu veya çok küçük dosya boyutu.</translation>
-    </message>
-    <message>
-        <source>Invalid ID3V2.4.0 frame. Frame size is supposed to be stored as a synchsafe integer, which uses only 7 bits in a byte, but the size uses all 8 bits, as in ID3V2.3.0. This will confuse some applications</source>
-        <translation type="vanished">Geçersiz ID3V2.4.0 çerçevesi. Çerçeve boyutunun &quot;synchsafe&quot; tamsayı olarak saklanması beklenir, ki bu bir baytta sadece 7 bit kullanır, fakat boyut ID3V2.3.0 için olduğu gibi tüm 8 biti kullanmaktadır. Bu, bazı uygulamaları karıştırır</translation>
-    </message>
-    <message>
-        <source>Deprecated TYER frame found in 2.4.0 tag alongside a TDRC frame.</source>
-        <translation type="vanished">2.4.0 etiketinde TDRC çerçevesinin yanında kullanımdan kaldırılmış eski TYER çerçevesi bulundu.</translation>
-    </message>
-    <message>
-        <source>Deprecated TYER frame found in 2.4.0 tag. It&apos;s supposed to be replaced by a TDRC frame.</source>
-        <translation type="vanished">2.4.0 etiketinde kullanımdan kaldırılmış eski TYER çerçevesi bulundu. Bunun yerine bir TDRC çerçevesi konması beklenir.</translation>
-    </message>
-    <message>
-        <source>Deprecated TDAT frame found in 2.4.0 tag alongside a TDRC frame.</source>
-        <translation type="vanished">2.4.0 etiketinde TDRC çerçevesinin yanında kullanımdan kaldırılmış eski TDAT çerçevesi bulundu.</translation>
-    </message>
-    <message>
-        <source>Deprecated TDAT frame found in 2.4.0 tag. It&apos;s supposed to be replaced by a TDRC frame.</source>
-        <translation type="vanished">2.4.0 etiketinde kullanımdan kaldırılmış eski TDAT çerçevesi bulundu. Bunun yerine bir TDRC çerçevesi konması beklenir.</translation>
-    </message>
-    <message>
-        <source>Invalid ID3V2.4.0 frame. Mismatched Data length indicator. Frame value is probably incorrect</source>
-        <translation type="vanished">Geçersiz ID3V2.4.0 çerçevesi. Veri uzunluğu göstergesi uyuşmuyor. Çerçeve değeri muhtemelen yanlıştır</translation>
-    </message>
-    <message>
-        <source>Invalid ID3V2.4.0 frame. Incorrect unsynchronization bit.</source>
-        <translation type="vanished">Geçersiz ID3V2.4.0 çerçevesi. Yanlış eşleşme biti.</translation>
-    </message>
-    <message>
-        <source>Unsupported value of text frame while reading an Id3V2.4.0 stream. It may be using an unsupported text encoding.</source>
-        <translation type="vanished">ID3V2.4.0 akışı okunurken desteklenmeyen metin çerçeve değeri. Desteklenmeyen bir metin kodlaması kullanıyor olabilir.</translation>
-    </message>
-    <message>
-        <source>The only supported tag found that is capable of storing song information is ID3V1, which has pretty limited capabilities.</source>
-        <translation type="vanished">Şarlı bilgisi saklama kabiliyetine sahip tespit edilen tek etiket ID3V1&apos;dir, ki kapasiteleri oldukça sınırlıdır.</translation>
-    </message>
-    <message>
-        <source>The ID3V1 tag should be located after the MPEG audio stream.</source>
-        <translation type="vanished">ID3V1 etiketinin MPEG ses akışından hemen sonra konumlanması gerekir.</translation>
-    </message>
-    <message>
-        <source>Invalid ID3V1 tag. File too short.</source>
-        <translation type="vanished">Geçersiz ID3V1 etiketi. Dosya çok kısa.</translation>
-    </message>
-    <message>
-        <source>Two ID3V1 tags found, but a file should have at most one of them.</source>
-        <translation type="vanished">İki ID3V1 etiketi tespit edildi, ancak bir dosyanın böyle en çok bir etikete sahip olması beklenir.</translation>
-    </message>
-    <message>
-        <source>ID3V1 tag contains fields padded with spaces alongside fields padded with zeroes. The standard only allows zeroes, but some tools use spaces. Even so, zero-padding and space-padding shouldn&apos;t be mixed.</source>
-        <translation type="vanished">ID3V1 etiketi boşluklarla ve bunların yanında sıfırlarla dolgulanmış alanlar içermektedir. Standart, sadece sıfırlara izin verir, fakat bazı araçlar boşluklar kullanır. Her durumda sıfır dolgularıyla boşluk dolguları karıştırılmamalıdır.</translation>
-    </message>
-    <message>
-        <source>ID3V1 tag contains fields that are padded with spaces mixed with zeroes. The standard only allows zeroes, but some tools use spaces. Even so, one character should be used for padding for the whole tag.</source>
-        <translation type="vanished">ID3V1 etiketi boşluklarla ve bunların yanında sıfırlarla dolgulanmış alanlar içermektedir. Standart, sadece sıfırlara izin verir, fakat bazı araçlar boşluklar kullanır. Her durumda bütün etiketi dolgulamak için tek bir karakter kullanılmalıdır.</translation>
-    </message>
-    <message>
-        <source>Invalid ID3V1 tag. Invalid characters in Name field.</source>
-        <translation type="vanished">Geçersiz ID3V1 etiketi. İsim alanında geçersiz karakterler.</translation>
-    </message>
-    <message>
-        <source>Invalid ID3V1 tag. Invalid characters in Artist field.</source>
-        <translation type="vanished">Geçersiz ID3V1 etiketi. Sanatçı alanında geçersiz karakterler.</translation>
-    </message>
-    <message>
-        <source>Invalid ID3V1 tag. Invalid characters in Album field.</source>
-        <translation type="vanished">Geçersiz ID3V1 etiketi. Albüm alanında geçersiz karakterler.</translation>
-    </message>
-    <message>
-        <source>Invalid ID3V1 tag. Invalid characters in Year field.</source>
-        <translation type="vanished">Geçersiz ID3V1 etiketi. Sene alanında geçersiz karakterler.</translation>
-    </message>
-    <message>
-        <source>Invalid ID3V1 tag. Invalid characters in Comment field.</source>
-        <translation type="vanished">Geçersiz ID3V1 etiketi. Yorum alanında geçersiz karakterler.</translation>
-    </message>
-    <message>
-        <source>Broken stream found.</source>
-        <translation type="vanished">Hasarlı akış tespit edildi.</translation>
-    </message>
-    <message>
-        <source>Broken stream found. Since other streams follow, it is possible that players and tools will have problems using the file. Removing the stream is recommended.</source>
-        <translation type="vanished">Hasarlı akış tespit edildi. Başka akışlar takip ettiğinden dolayı oynatıcıların ve araçların bu dosyayı kullanmakta sorun yaşamaları muhtemeldir. Akışın kaldırılması tavsiye edilir.</translation>
-    </message>
-    <message>
-        <source>Truncated MPEG stream found. The cause for this seems to be that the file was truncated.</source>
-        <translation type="vanished">Kesik MPEG akışı tespit edildi. Bunun sebebi dosyanın kesik olması gibi görünüyor.</translation>
-    </message>
-    <message>
-        <source>Truncated MPEG stream found. Since other streams follow, it is possible that players and tools will have problems using the file. Removing the stream or padding it with 0 to reach its declared size is strongly recommended.</source>
-        <translation type="vanished">Kesik MPEG akışı tespit edildi. Başka akışlar takip ettiğinden dolayı oynatıcıların ve araçların bu dosyayı kullanmakta sorun yaşamaları muhtemeldir. Akışın kaldırılması veya beyan edilen boyuta ulaşıncaya dek 0 ile dolgulanması hararetle tavsiye edilir.</translation>
-    </message>
-    <message>
-        <source>Not enough remaining bytes to create an UnknownDataStream.</source>
-        <translation type="vanished">Bilinmeyen veri akışı (UnknownDataStream) oluşturmak için kalan bayt sayısı yetersiz.</translation>
-    </message>
-    <message>
-        <source>Unknown stream found.</source>
-        <translation type="vanished">Bilinmeyen akış tespit edildi.</translation>
-    </message>
-    <message>
-        <source>Unknown stream found. Since other streams follow, it is possible that players and tools will have problems using the file. Removing the stream is recommended.</source>
-        <translation type="vanished">Bilinmeyen akış tespit edildi. Başka akışlar takip ettiğinden dolayı oynatıcıların ve araçların bu dosyayı kullanmakta sorun yaşamaları muhtemeldir. Akışın kaldırılması tavsiye edilir.</translation>
-    </message>
-    <message>
-        <source>File contains null streams.</source>
-        <translation type="vanished">Dosya boş akışlar içermektedir.</translation>
-    </message>
-    <message>
-        <source>Invalid Lyrics stream tag. File too short.</source>
-        <translation type="vanished">Geçersiz Şarkı Sözleri akış etiketi. Dosya çok kısa.</translation>
-    </message>
-    <message>
-        <source>Two Lyrics tags found, but only one is supported.</source>
-        <translation type="vanished">İki Şarkı Sözleri etiketi tespit edildi, ancak sadece bir tanesi desteklenmektedir.</translation>
-    </message>
-    <message>
-        <source>Invalid Lyrics stream tag. Unexpected characters found.</source>
-        <translation type="vanished">Geçersiz Şarkı Sözleri akış etiketi. Beklenmeyen karakterler tespit edildi.</translation>
-    </message>
-    <message>
-        <source>Multiple fields with the same name were found in a Lyrics tag, but only one is supported.</source>
-        <translation type="vanished">Şarkı Sözleri etiketinde aynı isimli birçok alan tespit edildi, ancak sadece bir tanesi desteklenmektedir.</translation>
-    </message>
-    <message>
-        <source>Currently INF fields in Lyrics tags are not fully supported.</source>
-        <translation type="vanished">Güncel olarak Şarkı Sözleri etiketlerinde INF alanları tam olarak desteklenmemektedir.</translation>
-    </message>
-    <message>
-        <source>Invalid Ape Item. File too short.</source>
-        <translation type="vanished">Geçersiz Ape unsuru. Dosya çok kısa.</translation>
-    </message>
-    <message>
-        <source>Ape Item seems too big. Although the size may be any 32-bit integer, 256 bytes should be enough in practice. If this note is determined to be incorrect, it will be removed in the future.</source>
-        <translation type="vanished">Ape unsuru çok büyük gibi görünüyor. Her ne kadar boyut 32 bit üzerinde herhangi bir tamsayı olabilse dahi, pratikte 256 baytın yeterli olması beklenir. Bu not yanlış ise gelecekte kaldırılacaktır.</translation>
-    </message>
-    <message>
-        <source>Invalid Ape Item. Terminator not found for item name.</source>
-        <translation type="vanished">Geçersiz Ape unsuru. Unsur ismi için sonlandırıcı bulunamadı.</translation>
-    </message>
-    <message>
-        <source>Invalid Ape tag. Header expected but footer found.</source>
-        <translation type="vanished">Geçersiz Ape etiketi.Başlık bekleniyordu ancak altbilgi bulundu.</translation>
-    </message>
-    <message>
-        <source>Not an Ape tag. File too short.</source>
-        <translation type="vanished">Ape etiketi değil. Dosya çok kısa.</translation>
-    </message>
-    <message>
-        <source>Invalid Ape tag. Footer expected but header found.</source>
-        <translation type="vanished">Geçersiz Ape etiketi. Altbilgi bekleniyordu fakat başlık bulundu.</translation>
-    </message>
-    <message>
-        <source>Invalid Ape tag. Mismatch between header and footer.</source>
-        <translation type="vanished">Geçersiz Ape etiketi. Başlık ile altbilgi arasında tutarsızlık var.</translation>
-    </message>
-    <message>
-        <source>Two Ape tags found, but only one is supported.</source>
-        <translation type="vanished">İki Ape etiketi tespit edildi, ancak sadece bir tanesi desteklenir.</translation>
-    </message>
-    <message>
-        <source>Ape item flags not supported.</source>
-        <translation type="vanished">Ape unsurunun bayrakları desteklenmemektedir.</translation>
-    </message>
-    <message>
-        <source>Unsupported Ape tag. Currently a missing header or footer are not supported.</source>
-        <translation type="vanished">Desteklenmeyen Ape etiketi. Güncel olarak eksik bir başlık veya altbilgi desteklenmemektedir.</translation>
-    </message>
-    <message>
-        <source>The file seems to have been changed in the (short) time that passed between parsing it and the initial search for pictures. If you think that&apos;s not the case, report a bug.</source>
-        <translation type="vanished">Dosya, ayrıştırılması ve ilk resim araması arasında geçen (kısa) süre içinde değiştirilmiş gibi görünüyor. Eğer bunun böyle olmadığını düşünüyorsanız, bir hata raporunda bulunun.</translation>
-    </message>
-    <message>
-        <source>No supported tag found that is capable of storing song information.</source>
-        <translation type="vanished">Şarkı bilgisi saklama kabiliyetine sahip hiçbir etiket tespit edilemedi.</translation>
-    </message>
-    <message>
-        <source>Too many TRACE notes added. The rest will be discarded.</source>
-        <translation type="vanished">Çok fazla TRACE notu eklendi. Geri kalanlar dikkate alınmayacaktır.</translation>
-    </message>
-    <message>
-        <source>Too many notes added. The rest will be discarded.</source>
-        <translation type="vanished">Çok fazla not eklendi. Geri kalanlar dikkate alınmayacaktır.</translation>
-    </message>
-    <message>
-        <source>Too many streams found. Aborting processing.</source>
-        <translation type="vanished">Çok fazla akış tespit edildi. İşleyiş iptal ediliyor.</translation>
-    </message>
-    <message>
-        <source>Unsupported stream found. It may be supported in the future if there&apos;s a real need for it.</source>
-        <translation type="vanished">Desteklenmeyen akış tespit edildi. Gelecekte, gerçekten ihtiyaç duyulması halinde desteklenebilir.</translation>
-    </message>
-    <message>
-        <source>The file was saved using the &quot;fast&quot; option. While this improves the saving speed, it may leave the notes in an inconsistent state, so you should rescan the file.</source>
-        <translation type="vanished">Dosya &quot;hızlı&quot; seçeneği kullanılarak kaydedilmiştir. Bu, her ne kadar kayıt süresini iyileştirse dahi, notları tutarsız bir durumda bırakabilir; dolayısıyla dosyayı tekrar taramanız tavsiye edilir.</translation>
-    </message>
-    <message>
-        <source>An error occurred while reading the file, so it wasn&apos;t fully processed. This usually happens when reading from external drives or USB sticks, in which case a workaround might be to copy the files to an internal drive.</source>
-        <translation type="vanished">Dosya okunurken bir hata meydana geldi, dolayısıyla tamamen işlenemedi. Bu genelde harici sürücülerden veya USB belleklerden okunurken meydana gelir, bu durumda geçici bir çözüm olarak dosyaları dahili bir sürücüye kopyalamak düşünülebilir.</translation>
     </message>
 </context>
 <context>
@@ -6004,38 +5495,6 @@ kutucukları işaretlemeniz gerekmektedir</translation>
 <context>
     <name>TagEdtPatternsDlgImpl</name>
     <message>
-        <source>%n	track number
-%a	artist
-%t	title
-%b	album
-%y	year
-%g	genre
-%r	rating (a lowercase letter)
-%c	composer
-%i	ignored
-
-To include the special characters &quot;%&quot;, &quot;[&quot;, &quot;]&quot; and &quot;%1&quot;, preced them by a &quot;%&quot;: &quot;%%&quot;, &quot;%[&quot;, &quot;%]&quot; and &quot;%%1&quot;
-
-For a pattern to be considered a &quot;file pattern&quot; (as opposed to a &quot;table pattern&quot;), it must contain at least a &quot;%1&quot;, even if you don&apos;t care about what&apos;s in the file&apos;s parent directory (see the fourth predefined pattern for an example.)
-
-Leading and trailing spaces are removed automatically from unbound fields after matching, so &quot;-[ ]%t&quot; is equivalent to &quot;-%t&quot; (but &quot;-[ ]%n&quot; is not equivalent to &quot;-%n&quot;, because %n is a fixed format field). However, all non-optional characters matter in the matching phase, including spaces.</source>
-        <translation type="vanished">%n	parça numarası
-%a	sanatçı
-%t	başlık
-%b	albüm
-%y	sene
-%g	tür
-%r	not (bir küçük harf)
-%c	bestekâr
-%i	dikkate alınmaz
-
-&quot;%&quot;, &quot;[&quot;, &quot;]&quot; et &quot;%1&quot; özel karakterleri dahil etmek için onları bir &quot;%&quot;: &quot;%%&quot;, &quot;%[&quot;, &quot;%]&quot; ve &quot;%%1&quot; ön eki ile kullanın
-
-Bir örüntünün &quot;dosya örüntüsü&quot; olarak kabul edilmesi için (tablo örüntüsüne zıt olarak), en az bir &quot;%1&quot; içermesi gerekir, üst dizinin içeriği sizin için önemli olmasa dahi (mesela ön tanımlı dördüncü örüntüye bakın.)
-
-Eşleştirmeden sonra, bağlı olmayan alanlardaki baştaki ve sondaki boşluklar otomatik olarak kaldırılır, bu nedenle &quot;-[ ]%t&quot; &quot;-%t&quot; ile eşdeğerdir (ancak &quot;-[ ]%n&quot; &quot;-%n&quot; ile eşdeğer değildir, çünkü %n sabit biçimli bir alandır). Bununla birlikte, boşluklar da dahil olmak üzere, isteğe bağlı olmayan tüm karakterler eşleştirme aşamasında önemlidir.</translation>
-    </message>
-    <message>
         <location filename="../TagEdtPatternsDlgImpl.cpp" line="53"/>
         <source>%n	track number
 %a	artist
@@ -6786,7 +6245,7 @@ Toplam süre: %1
     <message>
         <location filename="../StructuralTransformation.h" line="128"/>
         <source>Remove null streams</source>
-        <translation>Tüm boş akışları kaldır</translation>
+        <translation>Boş akışları kaldır</translation>
     </message>
     <message>
         <location filename="../StructuralTransformation.h" line="139"/>
@@ -6994,6 +6453,11 @@ Toplam süre: %1
     <name>WebDwnldModel</name>
     <message>
         <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="1167"/>
+        <source>Volume</source>
+        <translation>Ses düzeyi</translation>
+    </message>
+    <message>
+        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="1167"/>
         <source>Pos</source>
         <translation>Konum</translation>
     </message>
@@ -7011,11 +6475,6 @@ Toplam süre: %1
         <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="1167"/>
         <source>Composer</source>
         <translation>Bestekâr</translation>
-    </message>
-    <message>
-        <location filename="../AlbumInfoDownloaderDlgImpl.cpp" line="1167"/>
-        <source>Volume</source>
-        <translation>Ses düzeyi</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
I finally noticed that you had a GitHub mirror, and I think I figured out how to update the .ts file (the one at <https://sourceforge.net/p/mp3diags/tickets/3115/>) so here's the updated translation based on the latest mp3diags_fr_FR.ts file. Please note that I used the following command to update the .ts file:

 $ /usr/lib64/qt6/bin/lupdate mp3diags_fr_FR.ts -ts mp3diags_tr_TR.ts Updating 'mp3diags_tr_TR.ts'...
    Found 1152 source text(s) (147 new and 1005 already existing)
    Kept 126 obsolete entries
    Same-text heuristic provided 114 translation(s)

I hope everything is okay but if not please yell at me.